### PR TITLE
Workshop and stunt maps

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,11 @@
 				"/property:GenerateFullPaths=true",
 				"/consoleloggerparameters:NoSummary"
 			],
-			"problemMatcher": "$msCompile"
+			"problemMatcher": "$msCompile",
+			"group": {
+			  "kind": "build",
+			  "isDefault": true
+			},
 		},
 		{
 			"label": "publish",

--- a/DistanceTracker/Controllers/Area51Controller.cs
+++ b/DistanceTracker/Controllers/Area51Controller.cs
@@ -1,6 +1,5 @@
 ﻿using DistanceTracker.DALs;
 using DistanceTracker.Utils;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.Linq;
 using System.Threading.Tasks;

--- a/DistanceTracker/Controllers/EventController.cs
+++ b/DistanceTracker/Controllers/EventController.cs
@@ -1,7 +1,6 @@
 ﻿using DistanceTracker.DALs;
 using DistanceTracker.Models;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -35,8 +34,8 @@ namespace DistanceTracker.Controllers
 			var eventLeaderboardIDs = await EventDAL.GetEventLeaderboards(eventID);
 
 			// Get data
-			var recentFirstSightings = await EntryDAL.GetRecentFirstSightings(numRows:100, after:after, leaderboardIDs: eventLeaderboardIDs);
-			var recentImprovements = await HistoryDAL.GetRecentImprovements(numRows:100, after:after, leaderboardIDs: eventLeaderboardIDs);
+			var recentFirstSightings = await EntryDAL.GetRecentFirstSightings(numRows: 100, after: after, leaderboardIDs: eventLeaderboardIDs);
+			var recentImprovements = await HistoryDAL.GetRecentImprovements(numRows: 100, after: after, leaderboardIDs: eventLeaderboardIDs);
 
 			// Prepare empty view model
 			var recentActivity = new List<Activity>();
@@ -84,13 +83,13 @@ namespace DistanceTracker.Controllers
 				LeaderboardEntries = await EntryDAL.GetMultiLevelLeaderboard(maxEntryCount, eventLeaderboardIDs),
 				WinnersCircle = await EntryDAL.GetMultiLevelWinnersCircle(eventLeaderboardIDs),
 				OptimalTotalTime = await EntryDAL.GetOptimalTotalTime(eventLeaderboardIDs),
-				WRLog = await HistoryDAL.GetWRLog(leaderboardIDs:eventLeaderboardIDs),
+				WRLog = await HistoryDAL.GetWRLog(leaderboardIDs: eventLeaderboardIDs),
 				EventDetails = eventDetails,
 			};
 
 			// Add global time improvements to the entries
 			var globalTimeImprovements = await HistoryDAL.GetPastWeeksImprovement(leaderboardIDs: eventLeaderboardIDs);
-			foreach(var entry in viewModel.LeaderboardEntries)
+			foreach (var entry in viewModel.LeaderboardEntries)
 			{
 				var steamID = entry.Player.SteamID;
 				if (globalTimeImprovements.ContainsKey(steamID))

--- a/DistanceTracker/Controllers/EventController.cs
+++ b/DistanceTracker/Controllers/EventController.cs
@@ -82,9 +82,12 @@ namespace DistanceTracker.Controllers
 			{
 				LeaderboardEntries = await EntryDAL.GetMultiLevelLeaderboard(maxEntryCount, eventLeaderboardIDs),
 				WinnersCircle = await EntryDAL.GetMultiLevelWinnersCircle(eventLeaderboardIDs),
-				OptimalTotalTime = await EntryDAL.GetOptimalTotalTime(eventLeaderboardIDs),
+				OptimalTotalTime = await EntryDAL.GetOptimalTotal(eventLeaderboardIDs),
+				OptimalTotalStuntScore = await EntryDAL.GetOptimalTotal(eventLeaderboardIDs, true),
 				WRLog = await HistoryDAL.GetWRLog(leaderboardIDs: eventLeaderboardIDs),
 				EventDetails = eventDetails,
+				HasStuntScores = true,
+				HasTimeScores = true,
 			};
 
 			// Add global time improvements to the entries
@@ -94,7 +97,8 @@ namespace DistanceTracker.Controllers
 				var steamID = entry.Player.SteamID;
 				if (globalTimeImprovements.ContainsKey(steamID))
 				{
-					entry.LastWeeksTimeImprovement = globalTimeImprovements[steamID];
+					entry.LastWeeksTimeImprovement = globalTimeImprovements[steamID].Item1;
+					entry.LastWeeksScoreImprovement = globalTimeImprovements[steamID].Item2;
 				}
 			}
 

--- a/DistanceTracker/Controllers/HomeController.cs
+++ b/DistanceTracker/Controllers/HomeController.cs
@@ -30,7 +30,7 @@ namespace DistanceTracker.Controllers
 			return View(siteStats);
 		}
 
-		public IActionResult GlobalActivity() => View();
+		public IActionResult ActivityFeed() => View();
 
 		public async Task<IActionResult> GetGlobalRecentActivity(ulong? after = null)
 		{

--- a/DistanceTracker/Controllers/HomeController.cs
+++ b/DistanceTracker/Controllers/HomeController.cs
@@ -35,8 +35,8 @@ namespace DistanceTracker.Controllers
 		public async Task<IActionResult> GetGlobalRecentActivity(ulong? after = null)
 		{
 			// Get data
-			var recentFirstSightings = await EntryDAL.GetRecentFirstSightings(numRows:100, after:after);
-			var recentImprovements = await HistoryDAL.GetRecentImprovements(numRows:100, after:after);
+			var recentFirstSightings = await EntryDAL.GetRecentFirstSightings(numRows: 100, after: after);
+			var recentImprovements = await HistoryDAL.GetRecentImprovements(numRows: 100, after: after);
 
 			// Prepare empty view model
 			var recentActivity = new List<Activity>();
@@ -77,7 +77,7 @@ namespace DistanceTracker.Controllers
 		public async Task<IActionResult> GetWRActivity()
 		{
 			// Get data
-			var recentWRs = await HistoryDAL.GetRecentImprovements(numRows:100, rankCutoff: 1);
+			var recentWRs = await HistoryDAL.GetRecentImprovements(numRows: 100, rankCutoff: 1);
 
 			// Prepare empty view model
 			var recentActivity = new List<Activity>();
@@ -113,7 +113,7 @@ namespace DistanceTracker.Controllers
 		public async Task<IActionResult> GetTop100RecentActivity()
 		{
 			// Get data
-			var recentTop100 = await HistoryDAL.GetRecentImprovements(numRows:100, rankCutoff: 100);
+			var recentTop100 = await HistoryDAL.GetRecentImprovements(numRows: 100, rankCutoff: 100);
 
 			// Prepare empty view model
 			var recentActivity = new List<Activity>();

--- a/DistanceTracker/Controllers/LeaderboardController.cs
+++ b/DistanceTracker/Controllers/LeaderboardController.cs
@@ -128,10 +128,11 @@ namespace DistanceTracker.Controllers
 
 		public async Task<IActionResult> Level(uint leaderboardID)
 		{
-			var leaderboardEntries = await EntryDAL.GetRankedLeaderboardEntriesForLevel(leaderboardID);
+			var leaderboard = await LeaderDAL.GetLeaderboard(leaderboardID);
+
+			var leaderboardEntries = await EntryDAL.GetRankedLeaderboardEntriesForLevel(leaderboardID, leaderboard.IsReverseRankOrder);
 			var recentNewSightings = await EntryDAL.GetRecentFirstSightings(numRows: 30, leaderboardIDs: new List<uint>() { leaderboardID });
 			var recentImprovements = await HistoryDAL.GetRecentImprovements(numRows: 30, leaderboardIDs: new List<uint>() { leaderboardID });
-			var leaderboard = await LeaderDAL.GetLeaderboard(leaderboardID);
 
 			var viewModel = new LeaderboardViewModel()
 			{

--- a/DistanceTracker/Controllers/LeaderboardController.cs
+++ b/DistanceTracker/Controllers/LeaderboardController.cs
@@ -108,7 +108,8 @@ namespace DistanceTracker.Controllers
 			{
 				LeaderboardEntries = await EntryDAL.GetGlobalLeaderboard(leaderboardIDs),
 				WinnersCircle = await EntryDAL.GetGlobalWinnersCircle(leaderboardIDs),
-				OptimalTotalTime = await EntryDAL.GetOptimalTotalTime(leaderboardIDs),
+				OptimalTotalTime = await EntryDAL.GetOptimalTotal(leaderboardIDs),
+				OptimalTotalStuntScore = await EntryDAL.GetOptimalTotal(leaderboardIDs, true),
 				WRLog = await HistoryDAL.GetWRLog(leaderboardIDs: leaderboardIDs),
 			};
 
@@ -119,7 +120,8 @@ namespace DistanceTracker.Controllers
 				var steamID = entry.Player.SteamID;
 				if (globalTimeImprovements.ContainsKey(steamID))
 				{
-					entry.LastWeeksTimeImprovement = globalTimeImprovements[steamID];
+					entry.LastWeeksTimeImprovement = globalTimeImprovements[steamID].Item1;
+					entry.LastWeeksScoreImprovement = globalTimeImprovements[steamID].Item2;
 				}
 			}
 

--- a/DistanceTracker/Controllers/LeaderboardController.cs
+++ b/DistanceTracker/Controllers/LeaderboardController.cs
@@ -20,12 +20,85 @@ namespace DistanceTracker.Controllers
 		public LeaderboardEntryHistoryDAL HistoryDAL { get; }
 		public LeaderboardDAL LeaderDAL { get; }
 
+		public async Task<IActionResult> OfficialGlobal()
+		{
+			var leaderboards = await LeaderDAL.GetLeaderboards(true);
+			var leaderboardIDs = leaderboards.Select(x => x.ID).ToList();
+			var viewModel = await GetOverviewForLeaderboardIDs(leaderboardIDs);
+			viewModel.LeaderboardName = "Global Leaderboard (All Official Levels)";
+			viewModel.HasTimeScores = true;
+			viewModel.HasStuntScores = true;
+			return View("Overview", viewModel);
+		}
+
 		public async Task<IActionResult> OfficialSprint()
 		{
-			var leaderboards = await LeaderDAL.GetOfficialLeaderboards();
+			var leaderboards = await LeaderDAL.GetLeaderboards(true, LevelType.Sprint);
 			var leaderboardIDs = leaderboards.Select(x => x.ID).ToList();
 			var viewModel = await GetOverviewForLeaderboardIDs(leaderboardIDs);
 			viewModel.LeaderboardName = "Global Leaderboard (Official Sprint Levels)";
+			viewModel.HasTimeScores = true;
+			return View("Overview", viewModel);
+		}
+
+		public async Task<IActionResult> OfficialChallenge()
+		{
+			var leaderboards = await LeaderDAL.GetLeaderboards(true, LevelType.Challenge);
+			var leaderboardIDs = leaderboards.Select(x => x.ID).ToList();
+			var viewModel = await GetOverviewForLeaderboardIDs(leaderboardIDs);
+			viewModel.LeaderboardName = "Global Leaderboard (Official Challenge Levels)";
+			viewModel.HasTimeScores = true;
+			return View("Overview", viewModel);
+		}
+
+		public async Task<IActionResult> OfficialStunt()
+		{
+			var leaderboards = await LeaderDAL.GetLeaderboards(true, LevelType.Stunt);
+			var leaderboardIDs = leaderboards.Select(x => x.ID).ToList();
+			var viewModel = await GetOverviewForLeaderboardIDs(leaderboardIDs);
+			viewModel.LeaderboardName = "Global Leaderboard (Official Stunt Levels)";
+			viewModel.HasStuntScores = true;
+			return View("Overview", viewModel);
+		}
+
+		public async Task<IActionResult> WorkshopGlobal()
+		{
+			var leaderboards = await LeaderDAL.GetLeaderboards(false);
+			var leaderboardIDs = leaderboards.Select(x => x.ID).ToList();
+			var viewModel = await GetOverviewForLeaderboardIDs(leaderboardIDs);
+			viewModel.LeaderboardName = "Global Leaderboard (All Workshop Levels)";
+			viewModel.HasTimeScores = true;
+			viewModel.HasStuntScores = true;
+			return View("Overview", viewModel);
+		}
+
+		public async Task<IActionResult> WorkshopSprint()
+		{
+			var leaderboards = await LeaderDAL.GetLeaderboards(false, LevelType.Sprint);
+			var leaderboardIDs = leaderboards.Select(x => x.ID).ToList();
+			var viewModel = await GetOverviewForLeaderboardIDs(leaderboardIDs);
+			viewModel.LeaderboardName = "Global Leaderboard (Workshop Sprint Levels)";
+			viewModel.HasTimeScores = true;
+			return View("Overview", viewModel);
+		}
+
+		public async Task<IActionResult> WorkshopChallenge()
+		{
+			var leaderboards = await LeaderDAL.GetLeaderboards(false, LevelType.Challenge);
+			var leaderboardIDs = leaderboards.Select(x => x.ID).ToList();
+			var viewModel = await GetOverviewForLeaderboardIDs(leaderboardIDs);
+			viewModel.LeaderboardName = "Global Leaderboard (Workshop Challenge Levels)";
+			viewModel.HasTimeScores = true;
+			return View("Overview", viewModel);
+		}
+
+		public async Task<IActionResult> WorkshopStunt()
+		{
+			var leaderboards = await LeaderDAL.GetLeaderboards(false, LevelType.Stunt);
+			var leaderboardIDs = leaderboards.Select(x => x.ID).ToList();
+			var viewModel = await GetOverviewForLeaderboardIDs(leaderboardIDs);
+			viewModel.LeaderboardName = "Global Leaderboard (Workshop Stunt Levels)";
+			viewModel.HasStuntScores = true;
 			return View("Overview", viewModel);
 		}
 

--- a/DistanceTracker/Controllers/LeaderboardController.cs
+++ b/DistanceTracker/Controllers/LeaderboardController.cs
@@ -26,7 +26,7 @@ namespace DistanceTracker.Controllers
 			var leaderboardIDs = leaderboards.Select(x => x.ID).ToList();
 			var viewModel = new OverviewLeaderboardViewModel
 			{
-				LeaderboardEntries = await EntryDAL.GetGlobalLeaderboard(),
+				LeaderboardEntries = await EntryDAL.GetGlobalLeaderboard(leaderboardIDs.Count),
 				WinnersCircle = await EntryDAL.GetGlobalWinnersCircle(),
 				OptimalTotalTime = await EntryDAL.GetOptimalTotalTime(leaderboardIDs),
 				WRLog = await HistoryDAL.GetWRLog(leaderboardIDs: leaderboardIDs),
@@ -84,7 +84,7 @@ namespace DistanceTracker.Controllers
 
 			var groupedLevels = levels.GroupBy(x => x.LevelSet).OrderBy(x => {
 				var levelSet = x.First().LevelSet;
-				return levelSetOrder.ContainsKey(levelSet) ? levelSetOrder[levelSet] : 99999;
+				return levelSet != null && levelSetOrder.ContainsKey(levelSet) ? levelSetOrder[levelSet] : 99999;
 			})
 			.ThenBy(x => x.First().LevelSet);
 

--- a/DistanceTracker/Controllers/LeaderboardController.cs
+++ b/DistanceTracker/Controllers/LeaderboardController.cs
@@ -34,7 +34,7 @@ namespace DistanceTracker.Controllers
 
 			// Add global time improvements to the entries
 			var globalTimeImprovements = await HistoryDAL.GetPastWeeksImprovement(leaderboardIDs: leaderboardIDs);
-			foreach(var entry in viewModel.LeaderboardEntries)
+			foreach (var entry in viewModel.LeaderboardEntries)
 			{
 				var steamID = entry.Player.SteamID;
 				if (globalTimeImprovements.ContainsKey(steamID))
@@ -49,8 +49,8 @@ namespace DistanceTracker.Controllers
 		public async Task<IActionResult> Level(uint leaderboardID)
 		{
 			var leaderboardEntries = await EntryDAL.GetRankedLeaderboardEntriesForLevel(leaderboardID);
-			var recentNewSightings = await EntryDAL.GetRecentFirstSightings(numRows:30, leaderboardIDs: new List<uint>() {leaderboardID} );
-			var recentImprovements = await HistoryDAL.GetRecentImprovements(numRows:30, leaderboardIDs: new List<uint>() {leaderboardID});
+			var recentNewSightings = await EntryDAL.GetRecentFirstSightings(numRows: 30, leaderboardIDs: new List<uint>() { leaderboardID });
+			var recentImprovements = await HistoryDAL.GetRecentImprovements(numRows: 30, leaderboardIDs: new List<uint>() { leaderboardID });
 			var leaderboard = await LeaderDAL.GetLeaderboard(leaderboardID);
 
 			var viewModel = new LeaderboardViewModel()
@@ -82,7 +82,8 @@ namespace DistanceTracker.Controllers
 				{ "Legacy", 9},
 			};
 
-			var groupedLevels = levels.GroupBy(x => x.LevelSet).OrderBy(x => {
+			var groupedLevels = levels.GroupBy(x => x.LevelSet).OrderBy(x =>
+			{
 				var levelSet = x.First().LevelSet;
 				return levelSet != null && levelSetOrder.ContainsKey(levelSet) ? levelSetOrder[levelSet] : 99999;
 			})

--- a/DistanceTracker/Controllers/LeaderboardController.cs
+++ b/DistanceTracker/Controllers/LeaderboardController.cs
@@ -20,14 +20,21 @@ namespace DistanceTracker.Controllers
 		public LeaderboardEntryHistoryDAL HistoryDAL { get; }
 		public LeaderboardDAL LeaderDAL { get; }
 
-		public async Task<IActionResult> Global()
+		public async Task<IActionResult> OfficialSprint()
 		{
 			var leaderboards = await LeaderDAL.GetOfficialLeaderboards();
 			var leaderboardIDs = leaderboards.Select(x => x.ID).ToList();
+			var viewModel = await GetOverviewForLeaderboardIDs(leaderboardIDs);
+			viewModel.LeaderboardName = "Global Leaderboard (Official Sprint Levels)";
+			return View("Overview", viewModel);
+		}
+
+		private async Task<OverviewLeaderboardViewModel> GetOverviewForLeaderboardIDs(List<uint> leaderboardIDs)
+		{
 			var viewModel = new OverviewLeaderboardViewModel
 			{
-				LeaderboardEntries = await EntryDAL.GetGlobalLeaderboard(leaderboardIDs.Count),
-				WinnersCircle = await EntryDAL.GetGlobalWinnersCircle(),
+				LeaderboardEntries = await EntryDAL.GetGlobalLeaderboard(leaderboardIDs),
+				WinnersCircle = await EntryDAL.GetGlobalWinnersCircle(leaderboardIDs),
 				OptimalTotalTime = await EntryDAL.GetOptimalTotalTime(leaderboardIDs),
 				WRLog = await HistoryDAL.GetWRLog(leaderboardIDs: leaderboardIDs),
 			};
@@ -43,7 +50,7 @@ namespace DistanceTracker.Controllers
 				}
 			}
 
-			return View(viewModel);
+			return viewModel;
 		}
 
 		public async Task<IActionResult> Level(uint leaderboardID)

--- a/DistanceTracker/Controllers/LeaderboardController.cs
+++ b/DistanceTracker/Controllers/LeaderboardController.cs
@@ -145,11 +145,11 @@ namespace DistanceTracker.Controllers
 			return View(viewModel);
 		}
 
-		public IActionResult Levels() => View();
+		public IActionResult Levels(string q) => View("Levels", q);
 
-		public async Task<IActionResult> GetLevels()
+		public async Task<IActionResult> SearchLevels(string q = null)
 		{
-			var levels = await LeaderDAL.GetLevels();
+			var levels = await LeaderDAL.SearchLevels(q);
 			var levelSetOrder = new Dictionary<string, int>()
 			{
 				{ "Ignition", 1},

--- a/DistanceTracker/Controllers/PlayerController.cs
+++ b/DistanceTracker/Controllers/PlayerController.cs
@@ -157,6 +157,12 @@ namespace DistanceTracker.Controllers
 					},
 				};
 
+				// Skip levels that are over the limit
+				if(groupedHistogramDataPoints.FirstOrDefault(x => x.Key == percentileRank.LeaderboardID) == null)
+				{
+					continue;
+				}
+
 				// Create the data point dictionary for the histogram
 				var histogramDataPoints = groupedHistogramDataPoints
 					.First(x => x.Key == percentileRank.LeaderboardID)
@@ -170,6 +176,9 @@ namespace DistanceTracker.Controllers
 
 				histograms.Add(histogram);
 			}
+
+			// TODO: This limit is here until I rewrite the global comparisons to be searchable
+			histograms = histograms.Take(100).ToList();
 
 			return new JsonResult(histograms.GroupBy(x => x.Leaderboard.LevelSet).ToDictionary(x => x.Key, x => x.ToList()));
 		}

--- a/DistanceTracker/Controllers/PlayerController.cs
+++ b/DistanceTracker/Controllers/PlayerController.cs
@@ -187,10 +187,12 @@ namespace DistanceTracker.Controllers
 		{
 			var players = await SteamDAL.GetPlayerSummaries(steamID);
 			var player = players.FirstOrDefault();
+			var background = await SteamDAL.GetProfileBackground(steamID);
 			if (player != null)
 			{
 				await PlayerDAL.UpdateSteamAvatar(steamID, player.Avatar);
 				await PlayerDAL.UpdateSteamName(steamID, player.PersonaName);
+				await PlayerDAL.UpdateSteamBackground(steamID, background);
 			}
 
 			return RedirectToAction("Index", new { steamID = steamID });

--- a/DistanceTracker/Controllers/PlayerController.cs
+++ b/DistanceTracker/Controllers/PlayerController.cs
@@ -36,11 +36,11 @@ namespace DistanceTracker.Controllers
 			var officialLeaderboards = await LeaderDAL.GetLeaderboards(true);
 			var officalLeaderboardIDs = officialLeaderboards.Select(x => x.ID).ToList();
 
-			var globalRanking = await EntryDAL.GetGlobalRankingForPlayer(steamID);
+			var globalRanking = await EntryDAL.GetGlobalRankingForPlayer(steamID, officalLeaderboardIDs);
 
 			var lastWeeksImprovements = await HistoryDAL.GetPastWeeksImprovements(steamID, officalLeaderboardIDs);
 			var pointsImprovement = NoodlePointsUtil.CalculateImprovement(lastWeeksImprovements);
-			var oldGlobalRank = await EntryDAL.GetGlobalRankingForPoints((int)globalRanking.NoodlePoints - pointsImprovement);
+			var oldGlobalRank = await EntryDAL.GetGlobalRankingForPoints((int)globalRanking.NoodlePoints - pointsImprovement, officalLeaderboardIDs);
 			var funStats = await PlayerDAL.GetFunStats(steamID);
 
 			var stats = new PlayerGlobalStats

--- a/DistanceTracker/Controllers/PlayerController.cs
+++ b/DistanceTracker/Controllers/PlayerController.cs
@@ -33,9 +33,12 @@ namespace DistanceTracker.Controllers
 
 		public async Task<IActionResult> GetGlobalStats(ulong steamID)
 		{
+			var officialLeaderboards = await LeaderDAL.GetOfficialLeaderboards();
+			var officalLeaderboardIDs = officialLeaderboards.Select(x => x.ID).ToList();
+
 			var globalRanking = await EntryDAL.GetGlobalRankingForPlayer(steamID);
 
-			var lastWeeksImprovements = await HistoryDAL.GetPastWeeksImprovements(steamID);
+			var lastWeeksImprovements = await HistoryDAL.GetPastWeeksImprovements(steamID, officalLeaderboardIDs);
 			var pointsImprovement = NoodlePointsUtil.CalculateImprovement(lastWeeksImprovements);
 			var oldGlobalRank = await EntryDAL.GetGlobalRankingForPoints((int)globalRanking.NoodlePoints - pointsImprovement);
 			var funStats = await PlayerDAL.GetFunStats(steamID);
@@ -150,6 +153,7 @@ namespace DistanceTracker.Controllers
 						LevelName = percentileRank.LevelName,
 						LeaderboardName = percentileRank.LeaderboardName,
 						LevelSet = percentileRank.LevelSet,
+						ImageURL = percentileRank.ImageURL,
 					},
 				};
 

--- a/DistanceTracker/Controllers/PlayerController.cs
+++ b/DistanceTracker/Controllers/PlayerController.cs
@@ -67,8 +67,8 @@ namespace DistanceTracker.Controllers
 
 		public async Task<IActionResult> GetRecentActivity(ulong steamID)
 		{
-			var recentFirstSightings = await EntryDAL.GetRecentFirstSightings(numRows:40, steamID:steamID);
-			var recentImprovements = await HistoryDAL.GetRecentImprovements(numRows:40, steamID:steamID);
+			var recentFirstSightings = await EntryDAL.GetRecentFirstSightings(numRows: 40, steamID: steamID);
+			var recentImprovements = await HistoryDAL.GetRecentImprovements(numRows: 40, steamID: steamID);
 
 			var recentActivity = new List<Activity>();
 			recentFirstSightings.ForEach(x => recentActivity.Add(new Activity()
@@ -178,13 +178,13 @@ namespace DistanceTracker.Controllers
 		{
 			var players = await SteamDAL.GetPlayerSummaries(steamID);
 			var player = players.FirstOrDefault();
-			if(player != null)
+			if (player != null)
 			{
 				await PlayerDAL.UpdateSteamAvatar(steamID, player.Avatar);
 				await PlayerDAL.UpdateSteamName(steamID, player.PersonaName);
 			}
 
-			return RedirectToAction("Index", new {steamID = steamID});
+			return RedirectToAction("Index", new { steamID = steamID });
 		}
 
 		[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]

--- a/DistanceTracker/Controllers/PlayerController.cs
+++ b/DistanceTracker/Controllers/PlayerController.cs
@@ -33,7 +33,7 @@ namespace DistanceTracker.Controllers
 
 		public async Task<IActionResult> GetGlobalStats(ulong steamID)
 		{
-			var officialLeaderboards = await LeaderDAL.GetOfficialLeaderboards();
+			var officialLeaderboards = await LeaderDAL.GetLeaderboards(true);
 			var officalLeaderboardIDs = officialLeaderboards.Select(x => x.ID).ToList();
 
 			var globalRanking = await EntryDAL.GetGlobalRankingForPlayer(steamID);

--- a/DistanceTracker/DALs/EventDAL.cs
+++ b/DistanceTracker/DALs/EventDAL.cs
@@ -23,12 +23,12 @@ namespace DistanceTracker.DALs
 			var command = new MySqlCommand(sql, Connection);
 			var reader = await command.ExecuteReaderAsync();
 
-			while(reader.Read())
+			while (reader.Read())
 			{
 				eventDetails.ID = reader.GetUInt32(0);
 				eventDetails.Name = reader.GetString(1);
-				eventDetails.StartTimeUTC = reader.IsDBNull(2) ? (ulong?) null : reader.GetUInt64(2);
-				eventDetails.EndTimeUTC = reader.IsDBNull(3) ? (ulong?) null : reader.GetUInt64(3);
+				eventDetails.StartTimeUTC = reader.IsDBNull(2) ? (ulong?)null : reader.GetUInt64(2);
+				eventDetails.EndTimeUTC = reader.IsDBNull(3) ? (ulong?)null : reader.GetUInt64(3);
 				eventDetails.EventBackgroundImageURL = reader.GetString(4);
 			}
 
@@ -45,7 +45,7 @@ namespace DistanceTracker.DALs
 			var command = new MySqlCommand(sql, Connection);
 			var reader = await command.ExecuteReaderAsync();
 
-			while(reader.Read())
+			while (reader.Read())
 			{
 				leaderboardIDs.Add(reader.GetUInt32(0));
 			}

--- a/DistanceTracker/DALs/GeneralDAL.cs
+++ b/DistanceTracker/DALs/GeneralDAL.cs
@@ -33,14 +33,14 @@ namespace DistanceTracker.DALs
 
 
 			var siteStats = new SiteStats();
-			while(reader.Read())
+			while (reader.Read())
 			{
 				siteStats.PlayerCount = reader.GetInt32(0);
 				siteStats.LeaderboardEntryCount = reader.GetInt32(1);
 				siteStats.ImprovementCount = reader.GetInt32(2);
 				siteStats.LeaderboardCount = reader.GetInt32(3);
 
-				
+
 				var updatedEntryTime = reader.GetUInt64(4);
 				var updatedImprovementTime = reader.GetUInt64(5);
 				var updatedTime = updatedEntryTime > updatedImprovementTime ? updatedEntryTime : updatedImprovementTime;

--- a/DistanceTracker/DALs/LeaderboardDAL.cs
+++ b/DistanceTracker/DALs/LeaderboardDAL.cs
@@ -140,7 +140,7 @@ namespace DistanceTracker.DALs
 					ImageURL = reader.GetString(2),
 					LeaderboardName = reader.GetString(3),
 					IsOfficial = reader.GetBoolean(4),
-					SteamLeaderboardID = reader.GetUInt64(5),
+					SteamLeaderboardID = reader.IsDBNull(5) ? (ulong?)null : reader.GetUInt64(5),
 					LevelSet = reader.IsDBNull(6) ? null : reader.GetString(6),
 					EntryCount = reader.IsDBNull(7) ? (uint?)null : reader.GetUInt32(7),
 					NewestTimeUTC = reader.IsDBNull(8) ? (ulong?)null : reader.GetUInt64(8),

--- a/DistanceTracker/DALs/LeaderboardDAL.cs
+++ b/DistanceTracker/DALs/LeaderboardDAL.cs
@@ -19,25 +19,29 @@ namespace DistanceTracker.DALs
 		{
 			Connection.Open();
 
-			var sql = $"SELECT ID, LevelName, LeaderboardName, IsOfficial, ImageURL, BronzeMedalTime, SilverMedalTime, GoldMedalTime, DiamondMedalTime FROM Leaderboards WHERE ID = {leaderboardID}";
+			var sql = $"SELECT ID, LevelName, ImageURL, LeaderboardName, IsOfficial, WorkshopFileID, Tags, LevelType, BronzeMedalTime, SilverMedalTime, GoldMedalTime, DiamondMedalTime FROM Leaderboards WHERE ID = {leaderboardID}";
 			var command = new MySqlCommand(sql, Connection);
 			var reader = await command.ExecuteReaderAsync();
 
 			Leaderboard leaderboard = null;
 			while (reader.Read())
 			{
-				var bronzeTime = reader.IsDBNull(5) ? 0 : reader.GetUInt32(5);
-				var silverTime = reader.IsDBNull(6) ? 0 : reader.GetUInt32(6);
-				var goldTime = reader.IsDBNull(7) ? 0 : reader.GetUInt32(7);
-				var diamondTime = reader.IsDBNull(8) ? 0 : reader.GetUInt32(8);
+				var bronzeTime = reader.IsDBNull(8) ? 0 : reader.GetUInt32(8);
+				var silverTime = reader.IsDBNull(9) ? 0 : reader.GetUInt32(9);
+				var goldTime = reader.IsDBNull(10) ? 0 : reader.GetUInt32(10);
+				var diamondTime = reader.IsDBNull(11) ? 0 : reader.GetUInt32(11);
 
 				leaderboard = new Leaderboard()
 				{
 					ID = reader.GetUInt32(0),
 					LevelName = reader.GetString(1),
-					LeaderboardName = reader.GetString(2),
-					IsOfficial = reader.GetBoolean(3),
-					ImageURL = reader.GetString(4),
+					ImageURL = reader.GetString(2),
+					LeaderboardName = reader.GetString(3),
+					IsOfficial = reader.GetBoolean(4),
+					WorkshopFileID = reader.IsDBNull(5) ? (uint?)null : reader.GetUInt32(5),
+					Tags = reader.IsDBNull(6) ? "" : reader.GetString(6),
+					LevelType = (LevelType)reader.GetUInt32(7),
+
 					MedalTimes = new MapMedalTimes(diamondTime, goldTime, silverTime, bronzeTime),
 				};
 			}

--- a/DistanceTracker/DALs/LeaderboardDAL.cs
+++ b/DistanceTracker/DALs/LeaderboardDAL.cs
@@ -1,6 +1,7 @@
 ﻿using DistanceTracker.Models;
 using MySqlConnector;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace DistanceTracker.DALs
@@ -45,15 +46,27 @@ namespace DistanceTracker.DALs
 			return leaderboard;
 		}
 
-		public async Task<List<Leaderboard>> GetOfficialLeaderboards()
+		public async Task<List<Leaderboard>> GetLeaderboards(bool? isOfficial = null, LevelType? levelType = null)
 		{
-			var leaderboards = new List<Leaderboard>();
 			Connection.Open();
+			var select = "SELECT ID, LevelName, LeaderboardName, IsOfficial FROM Leaderboards ";
 
-			var sql = "SELECT ID, LevelName, LeaderboardName, IsOfficial FROM Leaderboards WHERE IsOfficial = 1";
+			var clauses = new List<string>();
+			if(isOfficial.HasValue)
+			{
+				clauses.Add($"IsOfficial = {(isOfficial.Value ? 1 : 0)}");
+			}
+			if(levelType.HasValue)
+			{
+				clauses.Add($"LevelType = {levelType.Value:D}");
+			}
+			var where = (clauses.Count != 0 ? "WHERE " : "") + string.Join(" AND ", clauses);
+
+			var sql = select + where;
 			var command = new MySqlCommand(sql, Connection);
 			var reader = await command.ExecuteReaderAsync();
 
+			var leaderboards = new List<Leaderboard>();
 			while (reader.Read())
 			{
 				leaderboards.Add(new Leaderboard()

--- a/DistanceTracker/DALs/LeaderboardDAL.cs
+++ b/DistanceTracker/DALs/LeaderboardDAL.cs
@@ -54,9 +54,10 @@ namespace DistanceTracker.DALs
 			var command = new MySqlCommand(sql, Connection);
 			var reader = await command.ExecuteReaderAsync();
 
-			while(reader.Read())
+			while (reader.Read())
 			{
-				leaderboards.Add(new Leaderboard() {
+				leaderboards.Add(new Leaderboard()
+				{
 					ID = reader.GetUInt32(0),
 					LevelName = reader.GetString(1),
 					LeaderboardName = reader.GetString(2),
@@ -77,9 +78,10 @@ namespace DistanceTracker.DALs
 			var command = new MySqlCommand(sql, Connection);
 			var reader = await command.ExecuteReaderAsync();
 
-			while(reader.Read())
+			while (reader.Read())
 			{
-				leaderboards.Add(new Leaderboard() {
+				leaderboards.Add(new Leaderboard()
+				{
 					ID = reader.GetUInt32(0),
 					LevelName = reader.GetString(1),
 					LeaderboardName = reader.GetString(2),
@@ -131,7 +133,7 @@ namespace DistanceTracker.DALs
 			var reader = await command.ExecuteReaderAsync();
 
 			var levels = new List<Level>();
-			while(reader.Read())
+			while (reader.Read())
 			{
 				var level = new Level()
 				{
@@ -146,10 +148,10 @@ namespace DistanceTracker.DALs
 					NewestTimeUTC = reader.IsDBNull(8) ? (ulong?)null : reader.GetUInt64(8),
 					NewestImprovementUTC = reader.IsDBNull(9) ? (ulong?)null : reader.GetUInt64(9),
 				};
-				level.LatestUpdateUTC = level.NewestImprovementUTC.HasValue ? 
-					(level.NewestTimeUTC.HasValue 
-						? System.Math.Max(level.NewestTimeUTC.Value, level.NewestImprovementUTC.Value) 
-						: level.NewestTimeUTC) 
+				level.LatestUpdateUTC = level.NewestImprovementUTC.HasValue ?
+					(level.NewestTimeUTC.HasValue
+						? System.Math.Max(level.NewestTimeUTC.Value, level.NewestImprovementUTC.Value)
+						: level.NewestTimeUTC)
 					: null;
 
 				levels.Add(level);

--- a/DistanceTracker/DALs/LeaderboardDAL.cs
+++ b/DistanceTracker/DALs/LeaderboardDAL.cs
@@ -176,8 +176,8 @@ namespace DistanceTracker.DALs
 				level.LatestUpdateUTC = level.NewestImprovementUTC.HasValue ?
 					(level.NewestTimeUTC.HasValue
 						? System.Math.Max(level.NewestTimeUTC.Value, level.NewestImprovementUTC.Value)
-						: level.NewestTimeUTC)
-					: null;
+						: level.NewestImprovementUTC)
+					: level.NewestTimeUTC;
 
 				levels.Add(level);
 			}

--- a/DistanceTracker/DALs/LeaderboardEntryDAL.cs
+++ b/DistanceTracker/DALs/LeaderboardEntryDAL.cs
@@ -60,15 +60,15 @@ namespace DistanceTracker.DALs
 			{
 				conditions.Add($"le.LeaderboardID IN ({string.Join(",", leaderboardIDs)})");
 			}
-			
+
 			if (after.HasValue)
 			{
 				conditions.Add($"le.FirstSeenTimeUTC > {after}");
 			}
 
-			for(var i = 0; i < conditions.Count; i++)
+			for (var i = 0; i < conditions.Count; i++)
 			{
-				if(i == 0)
+				if (i == 0)
 				{
 					sql += $" WHERE {conditions[i]}";
 				}
@@ -174,7 +174,7 @@ namespace DistanceTracker.DALs
 
 		public async Task<List<OverviewRankedLeaderboardEntry>> GetMultiLevelLeaderboard(uint rankCutoff, List<uint> leaderboardIDs, int numRows = 100)
 		{
-			if(leaderboardIDs == null || leaderboardIDs.Count == 0)
+			if (leaderboardIDs == null || leaderboardIDs.Count == 0)
 			{
 				return new List<OverviewRankedLeaderboardEntry>();
 			}
@@ -239,7 +239,7 @@ namespace DistanceTracker.DALs
 		public async Task<uint> GetMaxEntryCount(List<uint> leaderboardIDs)
 		{
 			var whereClause = "";
-			if(leaderboardIDs != null  && leaderboardIDs.Count > 0)
+			if (leaderboardIDs != null && leaderboardIDs.Count > 0)
 			{
 				whereClause = $"WHERE LeaderboardID IN ({string.Join(",", leaderboardIDs)})";
 			}
@@ -548,7 +548,7 @@ namespace DistanceTracker.DALs
 
 		public async Task<List<WinnersCircleEntry>> GetMultiLevelWinnersCircle(List<uint> leaderboardIDs)
 		{
-			if(leaderboardIDs == null || leaderboardIDs.Count == 0)
+			if (leaderboardIDs == null || leaderboardIDs.Count == 0)
 			{
 				return new List<WinnersCircleEntry>();
 			}

--- a/DistanceTracker/DALs/LeaderboardEntryDAL.cs
+++ b/DistanceTracker/DALs/LeaderboardEntryDAL.cs
@@ -115,6 +115,11 @@ namespace DistanceTracker.DALs
 
 		public async Task<List<OverviewRankedLeaderboardEntry>> GetGlobalLeaderboard(List<uint> leaderboardIDs, int numRows = 100)
 		{
+			if(leaderboardIDs.Count == 0)
+			{
+				return new List<OverviewRankedLeaderboardEntry>();
+			}
+
 			Connection.Open();
 			var sql = @$"
 				SELECT global_leaderboard.*,
@@ -503,6 +508,11 @@ namespace DistanceTracker.DALs
 
 		public async Task<List<WinnersCircleEntry>> GetGlobalWinnersCircle(List<uint> leaderboardIDs)
 		{
+			if(leaderboardIDs.Count == 0)
+			{
+				return new List<WinnersCircleEntry>();
+			}
+
 			Connection.Open();
 			var sql = $@"
 				SELECT 

--- a/DistanceTracker/DALs/LeaderboardEntryDAL.cs
+++ b/DistanceTracker/DALs/LeaderboardEntryDAL.cs
@@ -46,7 +46,7 @@ namespace DistanceTracker.DALs
 		{
 			Connection.Open();
 			var sql = @$"
-				SELECT le.LeaderboardID, l.LevelName, Milliseconds, le.SteamID, p.Name, le.FirstSeenTimeUTC, le.UpdatedTimeUTC, p.SteamAvatar, l.ImageURL FROM LeaderboardEntries le 
+				SELECT le.LeaderboardID, l.LevelName, Milliseconds, le.SteamID, p.Name, le.FirstSeenTimeUTC, le.UpdatedTimeUTC, p.SteamAvatar, l.ImageURL, l.LevelType FROM LeaderboardEntries le 
 				LEFT JOIN Leaderboards l on l.ID = le.LeaderboardID 
 				LEFT JOIN Players p on p.SteamID = le.SteamID ";
 
@@ -98,6 +98,7 @@ namespace DistanceTracker.DALs
 					ID = le.LeaderboardID,
 					LevelName = reader.GetString(1),
 					ImageURL = reader.GetString(8),
+					LevelType = (LevelType)reader.GetUInt32(9),
 				};
 				le.Player = new Player()
 				{

--- a/DistanceTracker/DALs/LeaderboardEntryDAL.cs
+++ b/DistanceTracker/DALs/LeaderboardEntryDAL.cs
@@ -494,7 +494,7 @@ namespace DistanceTracker.DALs
 			return rankedEntries;
 		}
 
-		public async Task<List<RankedLeaderboardEntry>> GetRankedLeaderboardEntriesForLevel(uint leaderboardID)
+		public async Task<List<RankedLeaderboardEntry>> GetRankedLeaderboardEntriesForLevel(uint leaderboardID, bool reverse = false)
 		{
 			Connection.Open();
 			var sql = $@"
@@ -512,7 +512,7 @@ namespace DistanceTracker.DALs
 						*,
 						CASE WHEN `Rank` is NULL OR `Rank` > 1000 THEN 0 ELSE ROUND(1000.0 * (1.0 - SQRT(1.0 - POW((((`Rank` -1.0) / 1000.0) - 1.0), 2)))) END AS NoodlePoints
 					FROM(
-							SELECT Milliseconds, SteamID, RANK() OVER(ORDER BY Milliseconds ASC) as `Rank`, FirstSeenTimeUTC, UpdatedTimeUTC FROM LeaderboardEntries WHERE LeaderboardID = {leaderboardID}
+							SELECT Milliseconds, SteamID, RANK() OVER(ORDER BY Milliseconds {(reverse ? "DESC" : "ASC")}) as `Rank`, FirstSeenTimeUTC, UpdatedTimeUTC FROM LeaderboardEntries WHERE LeaderboardID = {leaderboardID}
 					) ranks
 				) le
 				LEFT JOIN Players p ON p.SteamID = le.SteamID

--- a/DistanceTracker/DALs/LeaderboardEntryHistoryDAL.cs
+++ b/DistanceTracker/DALs/LeaderboardEntryHistoryDAL.cs
@@ -32,7 +32,8 @@ namespace DistanceTracker.DALs
 					NewRank,
 					UpdatedTimeUTC,
 					p.SteamAvatar,
-					l.ImageURL
+					l.ImageURL,
+					l.LevelType
 				FROM LeaderboardEntryHistory leh
 				LEFT JOIN Leaderboards l on l.ID = leh.LeaderboardID
 				LEFT JOIN Players p on p.SteamID = leh.SteamID";
@@ -93,6 +94,7 @@ namespace DistanceTracker.DALs
 					ID = leh.LeaderboardID,
 					LevelName = reader.GetString(1),
 					ImageURL = reader.GetString(11),
+					LevelType = (LevelType)reader.GetUInt32(12),
 				};
 				leh.Player = new Player()
 				{

--- a/DistanceTracker/DALs/LeaderboardEntryHistoryDAL.cs
+++ b/DistanceTracker/DALs/LeaderboardEntryHistoryDAL.cs
@@ -108,7 +108,7 @@ namespace DistanceTracker.DALs
 			return entries;
 		}
 
-		public async Task<List<LeaderboardEntryHistory>> GetPastWeeksImprovements(ulong steamID)
+		public async Task<List<LeaderboardEntryHistory>> GetPastWeeksImprovements(ulong steamID, List<uint> leaderboardIDs)
 		{
 			Connection.Open();
 			var sql = @$"
@@ -127,7 +127,7 @@ namespace DistanceTracker.DALs
 				FROM LeaderboardEntryHistory leh 
 				LEFT JOIN Leaderboards l on l.ID = leh.LeaderboardID 
 				LEFT JOIN Players p on p.SteamID = leh.SteamID 
-				WHERE leh.SteamID = {steamID} 
+				WHERE leh.SteamID = {steamID} AND l.ID IN ({string.Join(",", leaderboardIDs)})
 					AND leh.UpdatedTimeUTC > {DateTimeOffset.UtcNow.AddDays(-7).ToUnixTimeMilliseconds()}";
 			var command = new MySqlCommand(sql, Connection);
 			var reader = await command.ExecuteReaderAsync();

--- a/DistanceTracker/DALs/LeaderboardEntryHistoryDAL.cs
+++ b/DistanceTracker/DALs/LeaderboardEntryHistoryDAL.cs
@@ -47,18 +47,18 @@ namespace DistanceTracker.DALs
 			{
 				conditions.Add($"leh.LeaderboardID IN ({string.Join(",", leaderboardIDs)})");
 			}
-			if(rankCutoff.HasValue)
+			if (rankCutoff.HasValue)
 			{
 				conditions.Add($"leh.NewRank <= {rankCutoff}");
 			}
-			if(after.HasValue)
+			if (after.HasValue)
 			{
 				conditions.Add($"leh.UpdatedTimeUTC > {after}");
 			}
-			
-			for(var i = 0; i < conditions.Count; i++)
+
+			for (var i = 0; i < conditions.Count; i++)
 			{
-				if(i == 0)
+				if (i == 0)
 				{
 					sql += $" WHERE {conditions[i]}";
 				}
@@ -168,7 +168,7 @@ namespace DistanceTracker.DALs
 		public async Task<Dictionary<ulong, long>> GetPastWeeksImprovement(List<ulong> steamIDs = null, List<uint> leaderboardIDs = null)
 		{
 			var leaderboardClause = "";
-			if(leaderboardIDs != null  && leaderboardIDs.Count > 0)
+			if (leaderboardIDs != null && leaderboardIDs.Count > 0)
 			{
 				leaderboardClause = $" AND l.ID IN ({string.Join(",", leaderboardIDs)})";
 			}
@@ -201,7 +201,7 @@ namespace DistanceTracker.DALs
 		public async Task<List<LeaderboardEntryHistory>> GetWRLog(int limit = 20, List<uint> leaderboardIDs = null)
 		{
 			var leaderboardClause = "";
-			if (leaderboardIDs != null  && leaderboardIDs.Count > 0)
+			if (leaderboardIDs != null && leaderboardIDs.Count > 0)
 			{
 				leaderboardClause = $"AND leh.LeaderboardID IN ({string.Join(",", leaderboardIDs)})";
 			}

--- a/DistanceTracker/DALs/PlayerDAL.cs
+++ b/DistanceTracker/DALs/PlayerDAL.cs
@@ -17,7 +17,7 @@ namespace DistanceTracker.DALs
 		public async Task<Player> GetPlayer(ulong steamID)
 		{
 			Connection.Open();
-			var sql = $"SELECT ID, SteamID, Name, SteamAvatar FROM Players WHERE SteamID = {steamID}";
+			var sql = $"SELECT ID, SteamID, Name, SteamAvatar, SteamBackground FROM Players WHERE SteamID = {steamID}";
 			var command = new MySqlCommand(sql, Connection);
 			var reader = await command.ExecuteReaderAsync();
 
@@ -30,6 +30,7 @@ namespace DistanceTracker.DALs
 					SteamID = reader.GetUInt64(1),
 					Name = reader.GetString(2),
 					SteamAvatar = reader.IsDBNull(3) ? null : reader.GetString(3),
+					SteamBackground = reader.IsDBNull(4) ? null : reader.GetString(4),
 				};
 			}
 			reader.Close();
@@ -84,6 +85,19 @@ namespace DistanceTracker.DALs
 
 			var command = new MySqlCommand(sql, Connection);
 			command.Parameters.AddWithValue("@steamName", steamName);
+			await command.ExecuteNonQueryAsync();
+
+			Connection.Close();
+		}
+
+		public async Task UpdateSteamBackground(ulong steamID, string steamBackground)
+		{
+			Connection.Open();
+
+			var sql = $"UPDATE Players SET SteamBackground = @steamBackground WHERE SteamID = {steamID}";
+
+			var command = new MySqlCommand(sql, Connection);
+			command.Parameters.AddWithValue("@steamBackground", steamBackground);
 			await command.ExecuteNonQueryAsync();
 
 			Connection.Close();

--- a/DistanceTracker/DALs/PlayerDAL.cs
+++ b/DistanceTracker/DALs/PlayerDAL.cs
@@ -80,7 +80,7 @@ namespace DistanceTracker.DALs
 		{
 			Connection.Open();
 
-			var sql = $"UPDATE Players SET Name = @steamName WHERE SteamID = {steamID}";
+			var sql = $"UPDATE Players SET Name = '@steamName' WHERE SteamID = {steamID}";
 
 			var command = new MySqlCommand(sql, Connection);
 			command.Parameters.AddWithValue("@steamName", steamName);
@@ -94,7 +94,8 @@ namespace DistanceTracker.DALs
 			Connection.Open();
 			var sql = $@"
 				WITH
-				  TracksCompleted AS(SELECT COUNT(*) AS TracksCompleted FROM LeaderboardEntries WHERE SteamID = {steamID}),
+				  OfficialTracksCompleted AS(SELECT COUNT(*) AS OfficialTracksCompleted FROM LeaderboardEntries le LEFT JOIN Leaderboards l ON le.LeaderboardID = l.ID WHERE l.IsOfficial = 1 AND SteamID = {steamID}),
+				  UnofficialTracksCompleted AS(SELECT COUNT(*) AS UnofficialTracksCompleted FROM LeaderboardEntries le LEFT JOIN Leaderboards l ON le.LeaderboardID = l.ID WHERE l.IsOfficial = 0 AND SteamID = {steamID}),
 				  TotalImprovements AS(SELECT COUNT(*) AS TotalImprovements FROM LeaderboardEntryHistory WHERE SteamID = {steamID}),
 				  FirstSeenTime AS(SELECT FirstSeenTimeUTC FROM LeaderboardEntries WHERE SteamID = {steamID} ORDER BY FirstSeenTimeUTC ASC LIMIT 1),
 				  MostActiveLevel AS(
@@ -111,7 +112,7 @@ namespace DistanceTracker.DALs
 					GROUP BY LevelName
 					LIMIT 1
 				)
-				SELECT* FROM TracksCompleted JOIN TotalImprovements JOIN FirstSeenTime JOIN MostActiveLevel";
+				SELECT* FROM OfficialTracksCompleted JOIN UnofficialTracksCompleted JOIN TotalImprovements JOIN FirstSeenTime JOIN MostActiveLevel";
 			var command = new MySqlCommand(sql, Connection);
 			var reader = await command.ExecuteReaderAsync();
 
@@ -120,11 +121,12 @@ namespace DistanceTracker.DALs
 			{
 				funStats = new FunStats()
 				{
-					TracksCompleted = reader.GetInt32(0),
-					TotalImprovements = reader.GetInt32(1),
-					FirstSeenTimeUTC = reader.GetUInt64(2),
-					MostImprovements = reader.GetInt32(3),
-					MostImprovementsLevel = reader.GetString(4),
+					OfficialTracksCompleted = reader.GetInt32(0),
+					UnofficialTracksCompleted = reader.GetInt32(1),
+					TotalImprovements = reader.GetInt32(2),
+					FirstSeenTimeUTC = reader.GetUInt64(3),
+					MostImprovements = reader.GetInt32(4),
+					MostImprovementsLevel = reader.GetString(5),
 				};
 			}
 			reader.Close();

--- a/DistanceTracker/DALs/SteamDAL.cs
+++ b/DistanceTracker/DALs/SteamDAL.cs
@@ -18,7 +18,7 @@ namespace DistanceTracker.DALs
 
 		public async Task<List<SteamPlayer>> GetPlayerSummaries(ulong steamID)
 		{
-			var url = $"http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key={SteamAPIKey}&steamids={steamID}";
+			var url = $"https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key={SteamAPIKey}&steamids={steamID}";
 			var wr = WebRequest.Create(url);
 
 			var response = await wr.GetResponseAsync();
@@ -30,6 +30,26 @@ namespace DistanceTracker.DALs
 			var players = json["response"]["players"].ToObject<List<SteamPlayer>>();
 
 			return players;
+		}
+
+		public async Task<string> GetProfileBackground(ulong steamID)
+		{
+			var url = $"https://api.steampowered.com/IPlayerService/GetProfileBackground/v1/?key={SteamAPIKey}&steamid={steamID}";
+			var wr = WebRequest.Create(url);
+
+			var response = await wr.GetResponseAsync();
+			var stream = response.GetResponseStream();
+			var reader = new StreamReader(stream);
+			var responseMessage = reader.ReadLine();
+
+			var json = JObject.Parse(responseMessage);
+			var bgImage = json["response"]["profile_background"]["image_large"]?.ToString();
+			var bgAnimated = json["response"]["profile_background"]["movie_webm"]?.ToString();
+			var background = string.IsNullOrEmpty(bgAnimated) ? bgImage : bgAnimated;
+
+			var bgURL = string.IsNullOrEmpty(background) ? null : $"https://cdn.akamai.steamstatic.com/steamcommunity/public/images/{background}";
+
+			return bgURL;
 		}
 	}
 }

--- a/DistanceTracker/DALs/SteamDAL.cs
+++ b/DistanceTracker/DALs/SteamDAL.cs
@@ -1,9 +1,7 @@
 ﻿using DistanceTracker.Models.Steam;
 using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -11,7 +9,8 @@ namespace DistanceTracker.DALs
 {
 	public class SteamDAL
 	{
-		public SteamDAL(Settings settings) {
+		public SteamDAL(Settings settings)
+		{
 			SteamAPIKey = settings.SteamAPIKey;
 		}
 

--- a/DistanceTracker/Enums/LevelType.cs
+++ b/DistanceTracker/Enums/LevelType.cs
@@ -1,0 +1,10 @@
+namespace DistanceTracker
+{
+	public enum LevelType
+	{
+		None = 0,
+		Sprint = 1,
+		Stunt = 2,
+		Challenge = 8,
+	}
+}

--- a/DistanceTracker/Models/FunStats.cs
+++ b/DistanceTracker/Models/FunStats.cs
@@ -2,7 +2,8 @@
 {
 	public class FunStats
 	{
-		public int TracksCompleted { get; set; }
+		public int OfficialTracksCompleted { get; set; }
+		public int UnofficialTracksCompleted { get; set; }
 		public int TotalImprovements { get; set; }
 		public ulong FirstSeenTimeUTC { get; set; }
 		public string FirstSeen

--- a/DistanceTracker/Models/GlobalRankedLeaderboardEntry.cs
+++ b/DistanceTracker/Models/GlobalRankedLeaderboardEntry.cs
@@ -3,8 +3,10 @@
 	public class OverviewRankedLeaderboardEntry : RankedLeaderboardEntry
 	{
 		public ulong TotalMilliseconds { get; set; }
+		public ulong TotalStuntScore { get; set; }
 		public uint NumTracksCompleted { get; set; }
 
 		public long LastWeeksTimeImprovement { get; set; }
+		public long LastWeeksScoreImprovement { get; set; }
 	}
 }

--- a/DistanceTracker/Models/Leaderboard.cs
+++ b/DistanceTracker/Models/Leaderboard.cs
@@ -8,6 +8,10 @@
 		public string LeaderboardName { get; set; }
 		public string LevelSet { get; set; }
 		public bool IsOfficial { get; set; }
+		public uint? WorkshopFileID { get; set; }
+		public string Tags { get; set; }
+		public LevelType LevelType { get; set; }
+		public bool IsReverseRankOrder { get => LevelType == LevelType.Stunt; }
 		public MapMedalTimes MedalTimes { get; set; }
 	}
 }

--- a/DistanceTracker/Models/LeaderboardEntry.cs
+++ b/DistanceTracker/Models/LeaderboardEntry.cs
@@ -9,7 +9,7 @@
 		{
 			get
 			{
-				return Formatter.TimeFromMs(Milliseconds);
+				return Leaderboard.LevelType == LevelType.Stunt ? Formatter.ElectronVolts(Milliseconds) : Formatter.TimeFromMs(Milliseconds);
 			}
 		}
 		public ulong SteamID { get; set; }

--- a/DistanceTracker/Models/LeaderboardEntryHistory.cs
+++ b/DistanceTracker/Models/LeaderboardEntryHistory.cs
@@ -12,14 +12,14 @@
 		{
 			get
 			{
-				return Formatter.TimeFromMs(NewMilliseconds);
+				return Leaderboard.LevelType == LevelType.Stunt ? Formatter.ElectronVolts(NewMilliseconds) : Formatter.TimeFromMs(NewMilliseconds);
 			}
 		}
 		public string TimeImprovement
 		{
 			get
 			{
-				return Formatter.TimeFromMs(OldMilliseconds - NewMilliseconds);
+				return Leaderboard.LevelType == LevelType.Stunt ? Formatter.ElectronVolts(NewMilliseconds - OldMilliseconds) : Formatter.TimeFromMs(OldMilliseconds - NewMilliseconds);
 			}
 		}
 		public uint OldRank { get; set; }

--- a/DistanceTracker/Models/Level.cs
+++ b/DistanceTracker/Models/Level.cs
@@ -7,7 +7,7 @@ namespace DistanceTracker.Models
 		public string ImageURL { get; set; }
 		public string LeaderboardName { get; set; }
 		public bool IsOfficial { get; set; }
-		public ulong SteamLeaderboardID { get; set; }
+		public ulong? SteamLeaderboardID { get; set; }
 		public string LevelSet { get; set; }
 		public uint? EntryCount { get; set; }
 		public ulong? NewestTimeUTC { get; set; }

--- a/DistanceTracker/Models/MapMedalTimes.cs
+++ b/DistanceTracker/Models/MapMedalTimes.cs
@@ -17,15 +17,15 @@
 
 		public string GetMedalCSS(ulong milliseconds)
 		{
-			if(milliseconds < DiamondTime)
+			if (milliseconds < DiamondTime)
 			{
 				return "medal-diamond";
 			}
-			if(milliseconds < GoldTime)
+			if (milliseconds < GoldTime)
 			{
 				return "medal-gold";
 			}
-			if(milliseconds < SilverTime)
+			if (milliseconds < SilverTime)
 			{
 				return "medal-silver";
 			}

--- a/DistanceTracker/Models/OverviewLeaderboardViewModel.cs
+++ b/DistanceTracker/Models/OverviewLeaderboardViewModel.cs
@@ -11,6 +11,7 @@ namespace DistanceTracker.Models
 		public List<OverviewRankedLeaderboardEntry> LeaderboardEntries { get; set; }
 		public List<LeaderboardEntryHistory> WRLog { get; set; }
 		public ulong OptimalTotalTime { get; set; }
+		public ulong OptimalTotalStuntScore { get; set; }
 		public ulong LastWeeksTimeImprovement { get; set; }
 		public Event EventDetails { get; set; }
 		public Player FirstPlace { get => LeaderboardEntries.Count > 0 ? LeaderboardEntries[0].Player : null; }

--- a/DistanceTracker/Models/OverviewLeaderboardViewModel.cs
+++ b/DistanceTracker/Models/OverviewLeaderboardViewModel.cs
@@ -4,6 +4,7 @@ namespace DistanceTracker.Models
 {
 	public class OverviewLeaderboardViewModel
 	{
+		public string LeaderboardName { get; set; }
 		public List<WinnersCircleEntry> WinnersCircle { get; set; }
 		public List<OverviewRankedLeaderboardEntry> LeaderboardEntries { get; set; }
 		public List<LeaderboardEntryHistory> WRLog { get; set; }

--- a/DistanceTracker/Models/OverviewLeaderboardViewModel.cs
+++ b/DistanceTracker/Models/OverviewLeaderboardViewModel.cs
@@ -5,6 +5,8 @@ namespace DistanceTracker.Models
 	public class OverviewLeaderboardViewModel
 	{
 		public string LeaderboardName { get; set; }
+		public bool HasTimeScores { get; set; }
+		public bool HasStuntScores { get; set; }
 		public List<WinnersCircleEntry> WinnersCircle { get; set; }
 		public List<OverviewRankedLeaderboardEntry> LeaderboardEntries { get; set; }
 		public List<LeaderboardEntryHistory> WRLog { get; set; }

--- a/DistanceTracker/Models/PercentileRank.cs
+++ b/DistanceTracker/Models/PercentileRank.cs
@@ -8,5 +8,6 @@
 		public string LevelName { get; set; }
 		public string LeaderboardName { get; set; }
 		public string LevelSet { get; set; }
+		public string ImageURL { get; set; }
 	}
 }

--- a/DistanceTracker/Models/Player.cs
+++ b/DistanceTracker/Models/Player.cs
@@ -22,7 +22,7 @@ namespace DistanceTracker.Models
 			{
 				var players = await steamDAL.GetPlayerSummaries(SteamID);
 				var player = players.FirstOrDefault();
-				if(player == null)
+				if (player == null)
 				{
 					SteamAvatar = "Unknown";
 				}
@@ -33,7 +33,7 @@ namespace DistanceTracker.Models
 				}
 			}
 
-			if(string.IsNullOrEmpty(suffix))
+			if (string.IsNullOrEmpty(suffix))
 			{
 				return SteamAvatar;
 			}

--- a/DistanceTracker/Models/Player.cs
+++ b/DistanceTracker/Models/Player.cs
@@ -10,6 +10,7 @@ namespace DistanceTracker.Models
 		public ulong SteamID { get; set; }
 		public string Name { get; set; }
 		public string SteamAvatar { get; set; }
+		public string SteamBackground { get; set; }
 
 		public async Task<string> GetSteamAvatar(SteamDAL steamDAL, PlayerDAL playerDAL, string suffix = null)
 		{

--- a/DistanceTracker/Models/Player.cs
+++ b/DistanceTracker/Models/Player.cs
@@ -34,7 +34,7 @@ namespace DistanceTracker.Models
 				}
 			}
 
-			if (string.IsNullOrEmpty(suffix))
+			if (string.IsNullOrEmpty(suffix) || SteamAvatar.EndsWith(".gif"))
 			{
 				return SteamAvatar;
 			}

--- a/DistanceTracker/Models/Steam/SteamPlayer.cs
+++ b/DistanceTracker/Models/Steam/SteamPlayer.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace DistanceTracker.Models.Steam
+﻿namespace DistanceTracker.Models.Steam
 {
 	public class SteamPlayer
 	{

--- a/DistanceTracker/Settings.cs
+++ b/DistanceTracker/Settings.cs
@@ -11,7 +11,10 @@ namespace DistanceTracker
 
 		public IConfiguration Configuration { get; }
 
-		public string ConnectionString { get => Configuration["ConnectionString"]; }
-		public string SteamAPIKey { get => Configuration["SteamAPIKey"]; }
+		//public string ConnectionString { get => Configuration["MYSQL_CONNECTION_STRING"]; } // From env
+		//public string SteamAPIKey { get => Configuration["STEAM_API_KEY"]; } // From env
+
+		public string ConnectionString { get; } = "server=localhost;uid=website;pwd=password;database=distance"; // Never commit the real connection string to git
+		public string SteamAPIKey { get; } = ""; // Fill in with your steam API key (never commit this to git)
 	}
 }

--- a/DistanceTracker/Utils/Formatter.cs
+++ b/DistanceTracker/Utils/Formatter.cs
@@ -27,14 +27,14 @@ namespace DistanceTracker
 		public static string TimeAgoFromUnixTime(ulong timestamp)
 		{
 			var currentTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-			var diff = currentTimestamp - (long) timestamp;
+			var diff = currentTimestamp - (long)timestamp;
 
 			var seconds = diff / 1000;
 			var minutes = seconds / 60;
 			var hours = minutes / 60;
 			var days = hours / 24;
 
-			if(days > 0)
+			if (days > 0)
 			{
 				return days > 1 ? $"{days} days ago" : $"{days} day ago";
 			}
@@ -48,7 +48,7 @@ namespace DistanceTracker
 			}
 			else
 			{
-				if(seconds == 0)
+				if (seconds == 0)
 				{
 					return "Just now";
 				}

--- a/DistanceTracker/Utils/Formatter.cs
+++ b/DistanceTracker/Utils/Formatter.cs
@@ -26,6 +26,11 @@ namespace DistanceTracker
 
 		public static string ElectronVolts(ulong milliseconds)
 		{
+			return ElectronVolts((long)milliseconds);
+		}
+
+		public static string ElectronVolts(long milliseconds)
+		{
 			return $"{milliseconds:n0} eV";
 		}
 

--- a/DistanceTracker/Utils/Formatter.cs
+++ b/DistanceTracker/Utils/Formatter.cs
@@ -24,6 +24,11 @@ namespace DistanceTracker
 			return output;
 		}
 
+		public static string ElectronVolts(ulong milliseconds)
+		{
+			return $"{milliseconds:n0} eV";
+		}
+
 		public static string TimeAgoFromUnixTime(ulong timestamp)
 		{
 			var currentTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();

--- a/DistanceTracker/Utils/NoodlePointsUtil.cs
+++ b/DistanceTracker/Utils/NoodlePointsUtil.cs
@@ -13,7 +13,7 @@ namespace DistanceTracker
 
 		public static int CalculateImprovement(List<LeaderboardEntryHistory> improvements)
 		{
-			return improvements.Sum(x => CalculateDifference((int) x.OldRank, (int) x.NewRank));
+			return improvements.Sum(x => CalculateDifference((int)x.OldRank, (int)x.NewRank));
 		}
 
 		public static int CalculateDifference(int oldRank, int newRank)
@@ -25,12 +25,12 @@ namespace DistanceTracker
 		{
 			// C# version of the SQL point calculation formula
 			//ROUND(1000.0 * (1.0 - SQRT(1.0 - POW((((`Rank` -1.0) / 1000.0) - 1.0), 2))))
-			if(rank > 1000)
+			if (rank > 1000)
 			{
 				return 0;
 			}
 
-			return (int) (1000.0 * (1.0 - Math.Sqrt(1.0 - Math.Pow(((rank - 1.0) / 1000.0) - 1.0, 2))));
+			return (int)(1000.0 * (1.0 - Math.Sqrt(1.0 - Math.Pow(((rank - 1.0) / 1000.0) - 1.0, 2))));
 		}
 	}
 }

--- a/DistanceTracker/Utils/NumberToStringConverter.cs
+++ b/DistanceTracker/Utils/NumberToStringConverter.cs
@@ -1,30 +1,27 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace DistanceTracker.Utils
 {
-    public class NumberToStringConverter : JsonConverter
-    {
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            JToken jt = JToken.ReadFrom(reader);
+	public class NumberToStringConverter : JsonConverter
+	{
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			JToken jt = JToken.ReadFrom(reader);
 
-            return jt.Value<long>();
-        }
+			return jt.Value<long>();
+		}
 
-        public override bool CanConvert(Type objectType)
-        {
-            return typeof(long).Equals(objectType)
-                || typeof(ulong).Equals(objectType);
-        }
+		public override bool CanConvert(Type objectType)
+		{
+			return typeof(long).Equals(objectType)
+				|| typeof(ulong).Equals(objectType);
+		}
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            serializer.Serialize(writer, value.ToString());
-        }
-    }
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			serializer.Serialize(writer, value.ToString());
+		}
+	}
 }

--- a/DistanceTracker/Views/Event/Overview.cshtml
+++ b/DistanceTracker/Views/Event/Overview.cshtml
@@ -191,33 +191,54 @@
 	}
 </style>
 
-<div class="text-center fade-in">
+<div class="text-center fade-in container" style="max-width 1800px">
 	<div class="row">
 		<div class="col-12">
 			<h1 class="display-4 stroke">@Model.EventDetails.Name</h1>
 		</div>
-		<div class="col-3">
+		<div class="col-4">
 			<h5 class="stroke">1st Place</h5>
+			@if(Model.FirstPlace != null)
+			{
 			<h2 class="stroke"><img src="@await Model.FirstPlace.GetSteamAvatar(steamDAL, playerDAL, "_medium")" /> @Model.FirstPlace.Name</h2>
+			}
 		</div>
-		<div class="col-3">
+		<div class="col-4">
 			<h5 class="stroke">2nd Place</h5>
+			@if(Model.SecondPlace != null)
+			{
 			<h2 class="stroke"><img src="@await Model.SecondPlace.GetSteamAvatar(steamDAL, playerDAL, "_medium")" /> @Model.SecondPlace.Name</h2>
+			}
 		</div>
-		<div class="col-3">
+		<div class="col-4">
 			<h5 class="stroke">3rd Place</h5>
+			@if(Model.ThirdPlace != null)
+			{
 			<h2 class="stroke"><img src="@await Model.ThirdPlace.GetSteamAvatar(steamDAL, playerDAL, "_medium")" /> @Model.ThirdPlace.Name</h2>
+			}
 		</div>
-		<div class="col-3" style="margin-top: 15px;">
+		<div class="col-12 col-xl-3"></div>
+		@if (Model.HasTimeScores)
+		{
+		<div class="col-6 col-xl">
 			<h5>Optimal Total Time</h5>
 			<h2 style="margin-bottom: 1px; margin-top: -6px;">@Formatter.TimeFromMs(Model.OptimalTotalTime)</h2>
 		</div>
+		}
+		@if (Model.HasStuntScores)
+		{
+		<div class="col-6 col-xl">
+			<h5>Optimal Total Stunt Score</h5>
+			<h2 style="margin-bottom: 1px; margin-top: -6px;">@Formatter.ElectronVolts(Model.OptimalTotalStuntScore)</h2>
+		</div>
+		}
+		<div class="col-12 col-xl-3"></div>
 	</div>
 
 	<hr />
 
 	<div class="row">
-		<div class="col-8">
+		<div class="col-12 col-xl-7">
 			<ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
 				<li class="nav-item">
 					<a class="nav-link active stroke event-tab-button" id="pills-home-tab" data-toggle="pill" href="#pills-leaderboard" role="tab">Event Leaderboard</a>
@@ -233,7 +254,8 @@
 							<tr>
 								<th class="text-left">Rank</th>
 								<th class="text-left">Player</th>
-								<th>Total Time</th>
+								@Html.Raw(Model.HasTimeScores ? "<th>Total Time</th>" : "")
+								@Html.Raw(Model.HasStuntScores ? "<th>Total Score</th>" : "")
 								<th># Tracks Completed</th>
 								<th>Points</th>
 								<th>Rating</th>
@@ -245,6 +267,8 @@
 								<tr>
 									<td class="text-left">@entry.Rank</td>
 									<td class="text-left"><a class="link" href="/Player?steamID=@entry.Player.SteamID">@entry.Player.Name</a></td>
+									@if (Model.HasTimeScores)
+									{
 									<td>
 										@Formatter.TimeFromMs(entry.TotalMilliseconds)
 										@if(entry.LastWeeksTimeImprovement > 0)
@@ -252,6 +276,17 @@
 											@Html.Raw($"( <i class=\"fas fa-arrow-up fa-sm text-success\"></i> {Formatter.TimeFromMs(entry.LastWeeksTimeImprovement)} )")
 										}
 									</td>
+									}
+									@if (Model.HasStuntScores)
+									{
+									<td>
+										@Formatter.TimeFromMs(entry.TotalStuntScore)
+										@if(entry.LastWeeksScoreImprovement > 0)
+										{
+											@Html.Raw($"( <i class=\"fas fa-arrow-up fa-sm text-success\"></i> {Formatter.ElectronVolts(entry.LastWeeksScoreImprovement)} )")
+										}
+									</td>
+									}
 									<td>@entry.NumTracksCompleted</td>
 									<td>@entry.NoodlePoints.ToString("0")</td>
 									<td>@entry.PlayerRating.ToString("0.00")</td>
@@ -278,7 +313,7 @@
 				</div>
 			</div>
 		</div>
-		<div class="col-4">
+		<div class="col-12 col-xl-5">
 			<canvas id="winnersCircle" style="margin-bottom: 15px;margin-top: 15px;"></canvas>
 			<h4 class="text-left"># First Place Records</h4>
 			<table class="table table-striped table-dark">
@@ -305,7 +340,7 @@
 					<tr>
 						<th class="text-left">Player</th>
 						<th class="text-left">Track</th>
-						<th>Time</th>
+						@Html.Raw(Model.HasTimeScores ? (Model.HasStuntScores ? "<th>Time/Score</th>" : "<th>Time</th>") : "<th>Score</th>")
 						<th>When</th>
 					</tr>
 				</thead>

--- a/DistanceTracker/Views/Home/ActivityFeed.cshtml
+++ b/DistanceTracker/Views/Home/ActivityFeed.cshtml
@@ -1,5 +1,5 @@
 ﻿@{
-	ViewData["Title"] = "Global Activity";
+	ViewData["Title"] = "Activity Feed";
 }
 
 <script>
@@ -112,9 +112,9 @@
 					<tr>
 						<th class="text-left">Player</th>
 						<th class="text-left">Track</th>
-						<th class="text-left" style="width: 200px">Rank</th>
-						<th class="text-left" style="width: 200px">Time</th>
-						<th class="text-left" style="width: 200px">When</th>
+						<th style="width: 200px">Rank</th>
+						<th style="width: 200px">Time/Score</th>
+						<th style="width: 200px">When</th>
 					</tr>
 				</thead>
 				<tbody id="recentActivity">

--- a/DistanceTracker/Views/Home/Top100Activity.cshtml
+++ b/DistanceTracker/Views/Home/Top100Activity.cshtml
@@ -4,10 +4,10 @@
 
 <script>
 	jQuery(function () {
-		getGlobalRecentActivity();
+		getTop100RecentActivity();
 	});
 
-	function getGlobalRecentActivity() {
+	function getTop100RecentActivity() {
 		$.ajax({
 			url: '/Home/GetTop100RecentActivity',
 			method: 'GET',
@@ -83,7 +83,7 @@
 						<th class="text-left">Player</th>
 						<th class="text-left">Track</th>
 						<th style="width: 200px">Rank</th>
-						<th style="width: 200px">Time</th>
+						<th style="width: 200px">Time/Score</th>
 						<th style="width: 200px">When</th>
 					</tr>
 				</thead>

--- a/DistanceTracker/Views/Home/WRActivity.cshtml
+++ b/DistanceTracker/Views/Home/WRActivity.cshtml
@@ -1,13 +1,13 @@
 ﻿@{
-	ViewData["Title"] = "Global Activity";
+	ViewData["Title"] = "World Record Activity";
 }
 
 <script>
 	jQuery(function () {
-		getGlobalRecentActivity();
+		getWRActivity();
 	});
 
-	function getGlobalRecentActivity() {
+	function getWRActivity() {
 		$.ajax({
 			url: '/Home/GetWRActivity',
 			method: 'GET',
@@ -83,7 +83,7 @@
 						<th class="text-left">Player</th>
 						<th class="text-left">Track</th>
 						<th style="width: 200px">Rank</th>
-						<th style="width: 200px">Time</th>
+						<th style="width: 200px">Time/Score</th>
 						<th style="width: 200px">When</th>
 					</tr>
 				</thead>

--- a/DistanceTracker/Views/Leaderboard/Level.cshtml
+++ b/DistanceTracker/Views/Leaderboard/Level.cshtml
@@ -22,9 +22,12 @@
 	}
 
 	.level-medal-times {
-		background: #222;
-		margin: 20px;
 		padding: 10px;
+	}
+
+	.level-medal-times > div {
+		background: #222;
+		padding: 20px;
 	}
 
 	.fit-content {
@@ -73,13 +76,27 @@ $('#pills-tab a').on('click', function (e) {
 		<div class="col-3">
 			<div class="info-card rounded-corners-large fit-content box-shadow">
 				<h5>World Record</h5>
-				<h2>@Formatter.TimeFromMs(BestEntry.Milliseconds)</h2>
+				@if(Model.Leaderboard.LevelType == LevelType.Stunt)
+				{
+					<h2>@Formatter.ElectronVolts(BestEntry.Milliseconds)</h2>
+				}
+				else
+				{
+					<h2>@Formatter.TimeFromMs(BestEntry.Milliseconds)</h2>
+				}
 			</div>
 		</div>
 		<div class="col-3">
 			<div class="info-card rounded-corners-large fit-content box-shadow">
 				<h5>World Record Gap</h5>
-				<h2>@Formatter.TimeFromMs(SecondBestEntry.Milliseconds-BestEntry.Milliseconds)</h2>
+				@if(Model.Leaderboard.LevelType == LevelType.Stunt)
+				{
+					<h2>@Formatter.ElectronVolts(BestEntry.Milliseconds-SecondBestEntry.Milliseconds)</h2>
+				}
+				else
+				{
+					<h2>@Formatter.TimeFromMs(SecondBestEntry.Milliseconds-BestEntry.Milliseconds)</h2>
+				}
 			</div>
 		</div>
 	</div>
@@ -99,29 +116,65 @@ $('#pills-tab a').on('click', function (e) {
 			<div class="tab-content" id="pills-tabContent">
 				<div class="tab-pane fade show active" id="pills-info" role="tabpanel">
 					<div class="row">
-						<div class="col-5 level-medal-times rounded-corners-large box-shadow">
-							<div class="medal-diamond medal-medium" style="margin-bottom: 5px;">
-								<div class="medal-mask"></div><img src="/images/medals/medal_loog.png" />
+						<div class="col-6 level-medal-times">
+							<div class="rounded-corners-large box-shadow">
+								<div class="medal-diamond medal-medium" style="margin-bottom: 5px;">
+									<div class="medal-mask"></div><img src="/images/medals/medal_loog.png" />
+								</div>
+								@if(Model.Leaderboard.LevelType == LevelType.Stunt)
+								{
+									<h2>@Formatter.ElectronVolts(Model.Leaderboard.MedalTimes.DiamondTime)</h2>
+								}
+								else
+								{
+									<h2>@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.DiamondTime)</h2>
+								}
 							</div>
-							<h2>@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.DiamondTime)</h2>
 						</div>
-						<div class="col-5 level-medal-times rounded-corners-large box-shadow">
-							<div class="medal-gold medal-medium" style="margin-bottom: 5px;">
-								<div class="medal-mask"></div><img src="/images/medals/medal_loog.png" />
+						<div class="col-6 level-medal-times">
+							<div class="rounded-corners-large box-shadow">
+								<div class="medal-gold medal-medium" style="margin-bottom: 5px;">
+									<div class="medal-mask"></div><img src="/images/medals/medal_loog.png" />
+								</div>
+								@if(Model.Leaderboard.LevelType == LevelType.Stunt)
+								{
+									<h2>@Formatter.ElectronVolts(Model.Leaderboard.MedalTimes.GoldTime)</h2>
+								}
+								else
+								{
+									<h2>@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.GoldTime)</h2>
+								}
 							</div>
-							<h2>@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.GoldTime)</h2>
 						</div>
-						<div class="col-5 level-medal-times rounded-corners-large box-shadow">
-							<div class="medal-silver medal-medium" style="margin-bottom: 5px;">
-								<div class="medal-mask"></div><img src="/images/medals/medal_loog.png" />
+						<div class="col-6 level-medal-times">
+							<div class="rounded-corners-large box-shadow">
+								<div class="medal-silver medal-medium" style="margin-bottom: 5px;">
+									<div class="medal-mask"></div><img src="/images/medals/medal_loog.png" />
+								</div>
+								@if(Model.Leaderboard.LevelType == LevelType.Stunt)
+								{
+									<h2>@Formatter.ElectronVolts(Model.Leaderboard.MedalTimes.SilverTime)</h2>
+								}
+								else
+								{
+									<h2>@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.SilverTime)</h2>
+								}
 							</div>
-							<h2>@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.SilverTime)</h2>
 						</div>
-						<div class="col-5 level-medal-times rounded-corners-large box-shadow">
-							<div class="medal-bronze medal-medium" style="margin-bottom: 5px;">
-								<div class="medal-mask"></div><img src="/images/medals/medal_loog.png" />
+						<div class="col-6 level-medal-times">
+							<div class="rounded-corners-large box-shadow">
+								<div class="medal-bronze medal-medium" style="margin-bottom: 5px;">
+									<div class="medal-mask"></div><img src="/images/medals/medal_loog.png" />
+								</div>
+								@if(Model.Leaderboard.LevelType == LevelType.Stunt)
+								{
+									<h2>@Formatter.ElectronVolts(Model.Leaderboard.MedalTimes.BronzeTime)</h2>
+								}
+								else
+								{
+									<h2>@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.BronzeTime)</h2>
+								}
 							</div>
-							<h2>@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.BronzeTime)</h2>
 						</div>
 					</div>
 				</div>
@@ -132,7 +185,7 @@ $('#pills-tab a').on('click', function (e) {
 								<tr>
 									<th class="text-left">Player</th>
 									<th class="text-left">Rank</th>
-									<th>Time</th>
+									<th>@(@Model.Leaderboard.LevelType == LevelType.Stunt ? "Score" : "Time")</th>
 									<th>When</th>
 								</tr>
 							</thead>
@@ -145,7 +198,14 @@ $('#pills-tab a').on('click', function (e) {
 											<a class="link" href="/Player?steamID=@entry.Player.SteamID">@entry.Player.Name</a>
 										</td>
 										<td class="text-left">@entry.NewRank ( <i class="fas fa-arrow-up fa-sm text-success"></i> @(entry.OldRank - entry.NewRank) )</td>
-										<td>@Formatter.TimeFromMs(entry.NewMilliseconds) ( <i class="fas fa-arrow-up fa-sm text-success"></i> @Formatter.TimeFromMs(entry.OldMilliseconds-entry.NewMilliseconds) )</td>
+										@if(Model.Leaderboard.LevelType == LevelType.Stunt)
+										{
+											<td>@Formatter.ElectronVolts(entry.NewMilliseconds) ( <i class="fas fa-arrow-up fa-sm text-success"></i> @Formatter.ElectronVolts(entry.NewMilliseconds-entry.OldMilliseconds) )</td>
+										}
+										else
+										{
+											<td>@Formatter.TimeFromMs(entry.NewMilliseconds) ( <i class="fas fa-arrow-up fa-sm text-success"></i> @Formatter.TimeFromMs(entry.OldMilliseconds-entry.NewMilliseconds) )</td>
+										}
 										<td>@Formatter.TimeAgoFromUnixTime(entry.UpdatedTimeUTC)</td>
 									</tr>
 								}
@@ -159,7 +219,7 @@ $('#pills-tab a').on('click', function (e) {
 							<thead>
 								<tr>
 									<th class="text-left">Player</th>
-									<th>Time</th>
+									<th>@(@Model.Leaderboard.LevelType == LevelType.Stunt ? "Score" : "Time")</th>
 									<th>When</th>
 								</tr>
 							</thead>
@@ -171,7 +231,14 @@ $('#pills-tab a').on('click', function (e) {
 											<img src="@await entry.Player.GetSteamAvatar(steamDAL, playerDAL)" />
 											<a class="link" href="/Player?steamID=@entry.Player.SteamID">@entry.Player.Name</a>
 										</td>
-										<td>@Formatter.TimeFromMs(entry.Milliseconds)</td>
+										@if(Model.Leaderboard.LevelType == LevelType.Stunt)
+										{
+											<td>@Formatter.ElectronVolts(entry.Milliseconds)</td>
+										}
+										else
+										{
+											<td>@Formatter.TimeFromMs(entry.Milliseconds)</td>
+										}
 										<td>@Formatter.TimeAgoFromUnixTime(entry.FirstSeenTimeUTC)</td>
 									</tr>
 								}
@@ -191,7 +258,7 @@ $('#pills-tab a').on('click', function (e) {
 							<th class="text-left">Player</th>
 							<th>Points</th>
 							<th>Rating</th>
-							<th>Time</th>
+							<th>@(@Model.Leaderboard.LevelType == LevelType.Stunt ? "Score" : "Time")</th>
 							<th>Delta</th>
 						</tr>
 					</thead>
@@ -212,8 +279,16 @@ $('#pills-tab a').on('click', function (e) {
 								</td>
 								<td>@entry.NoodlePoints.ToString("0")</td>
 								<td>@entry.PlayerRating.ToString("0.00")</td>
-								<td>@Formatter.TimeFromMs(entry.Milliseconds)</td>
-								<td>+@Formatter.TimeFromMs(entry.Milliseconds - BestEntry.Milliseconds)</td>
+								@if(Model.Leaderboard.LevelType == LevelType.Stunt)
+								{
+									<td>@Formatter.ElectronVolts(entry.Milliseconds)</td>
+									<td>-@Formatter.ElectronVolts(BestEntry.Milliseconds - entry.Milliseconds)</td>
+								}
+								else
+								{
+									<td>@Formatter.TimeFromMs(entry.Milliseconds)</td>
+									<td>+@Formatter.TimeFromMs(entry.Milliseconds - BestEntry.Milliseconds)</td>
+								}
 							</tr>
 						}
 					</tbody>

--- a/DistanceTracker/Views/Leaderboard/Level.cshtml
+++ b/DistanceTracker/Views/Leaderboard/Level.cshtml
@@ -9,7 +9,7 @@
 	ViewData["Title"] = Model.Leaderboard.LevelName;
 	var BestEntry = Model.LeaderboardEntries.First();
 	var SecondBestEntry = Model.LeaderboardEntries.FirstOrDefault(x => x.Rank != 1);
-	var HeaderHeightPX = 400;
+	var HeaderHeightPX = 450;
 	var TabHeightPX = 20;
 }
 
@@ -26,6 +26,20 @@
 		margin: 20px;
 		padding: 10px;
 	}
+
+	.fit-content {
+		width: fit-content;
+		margin: auto;
+	}
+
+	table.table.custom-scrollbar {
+		margin-bottom: 0px;
+	}
+
+	a, a:hover, a:visited, a:active {
+		color: inherit;
+		text-decoration: none;
+	}
 </style>
 
 <script>
@@ -38,27 +52,37 @@ $('#pills-tab a').on('click', function (e) {
 <div class="text-center fade-in" style="margin-left: 15px; margin-right: 15px;">
 	
 	<div style="margin-bottom: 50px; margin-top: 30px;" class="row">
-		<div class="col-12">
-			<h1 class="display-4 stroke">@Model.Leaderboard.LevelName</h1>
+		<div class="col-12 mb-3">
+			<h1 class="display-4 info-card rounded-corners-large fit-content box-shadow">
+				@Model.Leaderboard.LevelName 
+				<a target="_blank" href="https://steamcommunity.com/sharedfiles/filedetails/?id=@Model.Leaderboard.WorkshopFileID"><i class="fab fa-steam"></i></a>
+			</h1>
 		</div>
 		<div class="col-3">
-			<h5 class="stroke">Leader</h5>
-			<h2 class="stroke"><img src="@await BestEntry.Player.GetSteamAvatar(steamDAL, playerDAL, "_medium")" /> @BestEntry.Player.Name</h2>
+			<div class="info-card rounded-corners-large fit-content box-shadow">
+				<h5>Leader</h5>
+				<h2><img src="@await BestEntry.Player.GetSteamAvatar(steamDAL, playerDAL, "_medium")" /> @BestEntry.Player.Name</h2>
+			</div>
 		</div>
 		<div class="col-3">
-			<h5 class="stroke">Record Age</h5>
-			<h2 class="stroke">@Formatter.TimeAgoFromUnixTime(BestEntry.UpdatedTimeUTC)</h2>
+			<div class="info-card rounded-corners-large fit-content box-shadow">
+				<h5>Record Age</h5>
+				<h2>@Formatter.TimeAgoFromUnixTime(BestEntry.UpdatedTimeUTC)</h2>
+			</div>
 		</div>
 		<div class="col-3">
-			<h5 class="stroke">World Record</h5>
-			<h2 class="stroke">@Formatter.TimeFromMs(BestEntry.Milliseconds)</h2>
+			<div class="info-card rounded-corners-large fit-content box-shadow">
+				<h5>World Record</h5>
+				<h2>@Formatter.TimeFromMs(BestEntry.Milliseconds)</h2>
+			</div>
 		</div>
 		<div class="col-3">
-			<h5 class="stroke">World Record Gap</h5>
-			<h2 class="stroke">@Formatter.TimeFromMs(SecondBestEntry.Milliseconds-BestEntry.Milliseconds)</h2>
+			<div class="info-card rounded-corners-large fit-content box-shadow">
+				<h5>World Record Gap</h5>
+				<h2>@Formatter.TimeFromMs(SecondBestEntry.Milliseconds-BestEntry.Milliseconds)</h2>
+			</div>
 		</div>
 	</div>
-	<div class="divider"></div>
 	<div class="row">
 		<div class="col-3 offset-1">
 			<ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
@@ -66,38 +90,38 @@ $('#pills-tab a').on('click', function (e) {
 					<a class="nav-link active stroke" id="pills-home-tab" data-toggle="pill" href="#pills-info" role="tab">Level Info</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link stroke" id="pills-profile-tab" data-toggle="pill" href="#pills-improvements" role="tab">Recent Improvements</a>
+					<a class="nav-link stroke" id="pills-profile-tab" data-toggle="pill" href="#pills-improvements" role="tab">Improvements</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link stroke" id="pills-contact-tab" data-toggle="pill" href="#pills-sightings" role="tab">Recent First Sightings</a>
+					<a class="nav-link stroke" id="pills-contact-tab" data-toggle="pill" href="#pills-sightings" role="tab">First Sightings</a>
 				</li>
 			</ul>
 			<div class="tab-content" id="pills-tabContent">
 				<div class="tab-pane fade show active" id="pills-info" role="tabpanel">
 					<div class="row">
-						<div class="col-5 level-medal-times box-shadow">
+						<div class="col-5 level-medal-times rounded-corners-large box-shadow">
 							<div class="medal-diamond medal-medium" style="margin-bottom: 5px;">
 								<div class="medal-mask"></div><img src="/images/medals/medal_loog.png" />
 							</div>
-							<h2 class="stroke">@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.DiamondTime)</h2>
+							<h2>@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.DiamondTime)</h2>
 						</div>
-						<div class="col-5 level-medal-times box-shadow">
+						<div class="col-5 level-medal-times rounded-corners-large box-shadow">
 							<div class="medal-gold medal-medium" style="margin-bottom: 5px;">
 								<div class="medal-mask"></div><img src="/images/medals/medal_loog.png" />
 							</div>
-							<h2 class="stroke">@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.GoldTime)</h2>
+							<h2>@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.GoldTime)</h2>
 						</div>
-						<div class="col-5 level-medal-times box-shadow">
+						<div class="col-5 level-medal-times rounded-corners-large box-shadow">
 							<div class="medal-silver medal-medium" style="margin-bottom: 5px;">
 								<div class="medal-mask"></div><img src="/images/medals/medal_loog.png" />
 							</div>
-							<h2 class="stroke">@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.SilverTime)</h2>
+							<h2>@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.SilverTime)</h2>
 						</div>
-						<div class="col-5 level-medal-times box-shadow">
+						<div class="col-5 level-medal-times rounded-corners-large box-shadow">
 							<div class="medal-bronze medal-medium" style="margin-bottom: 5px;">
 								<div class="medal-mask"></div><img src="/images/medals/medal_loog.png" />
 							</div>
-							<h2 class="stroke">@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.BronzeTime)</h2>
+							<h2>@Formatter.TimeFromMs(Model.Leaderboard.MedalTimes.BronzeTime)</h2>
 						</div>
 					</div>
 				</div>
@@ -163,7 +187,7 @@ $('#pills-tab a').on('click', function (e) {
 				<table class="table table-striped table-dark sticky-headers custom-scrollbar">
 					<thead>
 						<tr>
-							<th class="text-left" width="100">Rank</th>
+							<th class="text-left" width="100" style="z-index: 1">Rank</th>
 							<th class="text-left">Player</th>
 							<th>Points</th>
 							<th>Rating</th>

--- a/DistanceTracker/Views/Leaderboard/Levels.cshtml
+++ b/DistanceTracker/Views/Leaderboard/Levels.cshtml
@@ -1,6 +1,7 @@
 ﻿@{
 	ViewData["Title"] = "All Levels";
 }
+@model string
 
 <style>
 .level-card .card {
@@ -9,25 +10,44 @@
 </style>
 
 <script>
+	var debounce = null;
 	jQuery(function () {
-		getLevels();
+		search();
+		
+		$('#searchQuery').on('input', function () {
+			clearTimeout(debounce);
+			debounce = setTimeout(search, 1000);
+		});
 	});
 
-	function getLevels() {
+	function search() {
+		var q = $('#searchQuery').val();
+		var searchResults = $('#searchResults');
+		searchResults.html('');
+		$('#levelsPlaceholder').show();
+		$('#noResults').hide();
+		$('#searchResultsMessage').hide();
+
 		$.ajax({
-			url: '/Leaderboard/GetLevels',
+			url: '/Leaderboard/SearchLevels',
 			method: 'GET',
+			data: {
+				q: q
+			},
 			success: async function (data) {
 				$('#levelsPlaceholder').hide();
-				var levels = $('#levels');
+				if (data.length > 0 && q.length > 0)
+				{
+					$('#searchResultsMessage').show();
+				}
 				for (var i = 0; i < data.length; i++) {
 					var levelSet = data[i];
 					for (var j = 0; j < data[i].length; j++) {
 						var level = levelSet[j];
 						if (j == 0) {
-							levels.append(`
+							searchResults.append(`
 								<div class="col-12 fade-in text-left">
-									<h1 style="margin-top: 30px;">${level.levelSet}</h1>
+									<h1 style="margin-top: 30px;">${level.levelSet ?? "Workshop"}</h1>
 									<hr />
 								</div>
 							`);
@@ -46,15 +66,19 @@
 								</a>
 							</div>
 						`);
-						levels.append(row);
+						searchResults.append(row);
 						if ((j + 1) % 4 == 0 && j > 0) {
 							await new Promise(r => setTimeout(r, 100));
 						}
 					}
 				}
+				
+				if (data.length == 0) {
+					$('#noResults').show();
+				}
 			},
 			error: function () {
-				toastr.error('Failed to load global stats for this player');
+				toastr.error('Failed to load level search results');
 			}
 		});
 	};
@@ -62,9 +86,18 @@
 
 <div class="container text-center fade-in">
 	<div class="row">
-		<div class="col">
-			<div id="levelsPlaceholder" class="lds-ellipsis"><div></div><div></div><div></div><div></div></div>
-			<div class="row" id="levels"></div>
+		<div class="col-12">
+			<form class="form mt-4 fade-in">
+				<div class="form-group" style="width:100%">
+					<input type="text" class="form-control" id="searchQuery" name="q" placeholder="Enter a level name" value="@Model">
+				</div>
+			</form>
+			<h4 class="text-left fade-in" id="searchResultsMessage">Search Results (Showing First 100 Results)</h4>
 		</div>
+		<div class="col-12">
+			<div id="levelsPlaceholder" class="lds-ellipsis"><div></div><div></div><div></div><div></div></div>
+			<div class="row" id="searchResults"></div>
+		</div>
+		<div id="noResults" class="col-12 text-center mt-4"><h2>No results 😐</h2></div>
 	</div>
 </div>

--- a/DistanceTracker/Views/Leaderboard/Oldest.cshtml
+++ b/DistanceTracker/Views/Leaderboard/Oldest.cshtml
@@ -54,7 +54,7 @@
 					<tr>
 						<th class="text-left">Player</th>
 						<th class="text-left">Track</th>
-						<th style="width: 200px">Time</th>
+						<th style="width: 200px">Time/Score</th>
 						<th style="width: 200px">When</th>
 					</tr>
 				</thead>

--- a/DistanceTracker/Views/Leaderboard/Overview.cshtml
+++ b/DistanceTracker/Views/Leaderboard/Overview.cshtml
@@ -88,7 +88,7 @@
 
 	<div class="row">
 		<div class="col-8">
-			<h4 class="text-left">Global Leaderboard (Official Sprints)</h4>
+			<h4 class="text-left">@Model.LeaderboardName</h4>
 			<table class="table table-striped table-dark">
 				<thead>
 					<tr>

--- a/DistanceTracker/Views/Leaderboard/Overview.cshtml
+++ b/DistanceTracker/Views/Leaderboard/Overview.cshtml
@@ -76,25 +76,38 @@
 	};
 </script>
 
-<div class="text-center">
+<div class="container text-center" style="max-width: 1800px">
 	<div class="row">
-		<div class="col">
+		<div class="col-12 col-xl-3"></div>
+		@if (Model.HasTimeScores)
+		{
+		<div class="col-6 col-xl">
 			<h5>Optimal Total Time</h5>
 			<h2 style="margin-bottom: 1px; margin-top: -6px;">@Formatter.TimeFromMs(Model.OptimalTotalTime)</h2>
 		</div>
+		}
+		@if (Model.HasStuntScores)
+		{
+		<div class="col-6 col-xl">
+			<h5>Optimal Total Stunt Score</h5>
+			<h2 style="margin-bottom: 1px; margin-top: -6px;">@Formatter.ElectronVolts(Model.OptimalTotalStuntScore)</h2>
+		</div>
+		}
+		<div class="col-12 col-xl-3"></div>
 	</div>
 
 	<hr />
 
 	<div class="row">
-		<div class="col-8">
+		<div class="col-12 col-xl-7">
 			<h4 class="text-left">@Model.LeaderboardName</h4>
 			<table class="table table-striped table-dark">
 				<thead>
 					<tr>
 						<th class="text-left">Rank</th>
 						<th class="text-left">Player</th>
-						<th>Total Time</th>
+						@Html.Raw(Model.HasTimeScores ? "<th>Total Time</th>" : "")
+						@Html.Raw(Model.HasStuntScores ? "<th>Total Score</th>" : "")
 						<th># Tracks Completed</th>
 						<th>Points</th>
 						<th>Rating</th>
@@ -106,6 +119,8 @@
 						<tr>
 							<td class="text-left">@entry.Rank</td>
 							<td class="text-left"><a class="link" href="/Player?steamID=@entry.Player.SteamID">@entry.Player.Name</a></td>
+							@if (Model.HasTimeScores)
+							{
 							<td>
 								@Formatter.TimeFromMs(entry.TotalMilliseconds)
 								@if(entry.LastWeeksTimeImprovement > 0)
@@ -113,6 +128,17 @@
 									@Html.Raw($"( <i class=\"fas fa-arrow-up fa-sm text-success\"></i> {Formatter.TimeFromMs(entry.LastWeeksTimeImprovement)} )")
 								}
 							</td>
+							}
+							@if (Model.HasStuntScores)
+							{
+							<td>
+								@Formatter.ElectronVolts(entry.TotalStuntScore)
+								@if(entry.LastWeeksScoreImprovement > 0)
+								{
+									@Html.Raw($"( <i class=\"fas fa-arrow-up fa-sm text-success\"></i> {Formatter.ElectronVolts(entry.LastWeeksScoreImprovement)} )")
+								}
+							</td>
+							}
 							<td>@entry.NumTracksCompleted</td>
 							<td>@entry.NoodlePoints.ToString("0")</td>
 							<td>@entry.PlayerRating.ToString("0.00")</td>
@@ -121,7 +147,7 @@
 				</tbody>
 			</table>
 		</div>
-		<div class="col-4">
+		<div class="col-12 col-xl-5">
 			<canvas id="winnersCircle" style="margin-bottom: 15px;margin-top: 15px;"></canvas>
 			<h4 class="text-left"># First Place Records</h4>
 			<table class="table table-striped table-dark">
@@ -148,7 +174,7 @@
 					<tr>
 						<th class="text-left">Player</th>
 						<th class="text-left">Track</th>
-						<th>Time</th>
+						@Html.Raw(Model.HasTimeScores ? Model.HasStuntScores ? "<th>Time/Score</th>" : "<th>Time</th>" : "<th>Score</th>")
 						<th>When</th>
 					</tr>
 				</thead>

--- a/DistanceTracker/Views/Player/Index.cshtml
+++ b/DistanceTracker/Views/Player/Index.cshtml
@@ -172,9 +172,11 @@
 				<td><div class="fade-in">${rankedEntry.noodlePointsString}</div></td>
 				<td><div class="fade-in">${rankedEntry.playerRatingString}</div></td>
 			</tr>
-		`);
+			`);
 			leaderboardRankingsTable.append(row);
-			await new Promise(r => setTimeout(r, 15));
+			if(i < 500) {
+				await new Promise(r => setTimeout(r, 15));
+			}
 		}
 
 		leaderboardSortingEnabled = true;
@@ -385,15 +387,19 @@
 <div class="text-center fade-in container">
 	<div class="row">
 		<div class="col-xl-3 col-12">
-			<div class="fade-in">
+			<div class="fade-in info-card box-shadow rounded-corners">
 				<div class="row">
 					<div class="col-4 col-xl-12">
 						<a href="http://steamcommunity.com/profiles/@Model.SteamID" target="_blank">
 							<img href="" src="@await Model.GetSteamAvatar(steamDAL, playerDAL, "_full")" />
 						</a>
-						<h2>@Model.Name <i title="Refresh Steam Profile Info" class="fas fa-sync fa-xxs pointer" id="refreshSteamInfo"></i></h2>
-						<hr />
+						<h2 style="text-overflow: ellipsis; overflow: hidden">@Model.Name <i title="Refresh Steam Profile Info" class="fas fa-sync fa-xxs pointer" id="refreshSteamInfo"></i></h2>
 					</div>
+				</div>
+			</div>
+			<hr />
+			<div class="fade-in info-card box-shadow rounded-corners">
+				<div class="row">
 					<div class="col-lg-12 col-xl-6">
 						<h5>Global Rank</h5>
 						<div id="globalRankPlaceholder" class="lds-ellipsis"><div></div><div></div><div></div><div></div></div>
@@ -415,7 +421,7 @@
 				</div>
 			</div>
 			<hr />
-			<div class="fade-in">
+			<div class="fade-in info-card box-shadow rounded-corners">
 				<div class="row text-left">
 					<div class="col-8">
 						<h6>Tracks Completed:</h6>
@@ -471,7 +477,7 @@
 			</ul>
 			<div class="tab-content" id="pills-tabContent">
 				<div class="tab-pane fade show active" id="pills-recent-activity" role="tabpanel" aria-labelledby="pills-recent-activity-tab">
-					<table class="table table-striped table-dark">
+					<table class="table table-striped table-dark box-shadow rounded-corners">
 						<thead>
 							<tr>
 								<th class="text-left" style="width: 100px">Track</th>
@@ -487,7 +493,7 @@
 					<div id="recentActivityPlaceholder" class="lds-ellipsis"><div></div><div></div><div></div><div></div></div>
 				</div>
 				<div class="tab-pane fade" id="pills-rankings" role="tabpanel" aria-labelledby="pills-rankings-tab">
-					<table class="table table-striped table-dark" style="table-layout: fixed">
+					<table class="table table-striped table-dark box-shadow rounded-corners" style="table-layout: fixed">
 						<thead>
 							<tr>
 								<th class="text-left" style="width: 100px">Track</th>

--- a/DistanceTracker/Views/Player/Index.cshtml
+++ b/DistanceTracker/Views/Player/Index.cshtml
@@ -24,6 +24,18 @@
 	.level-card .card {
 		background-color: #212529;
 	}
+
+	#backgroundVideo {
+		position: fixed;
+		@* left: 50%;
+		transform: translateX(-50%);
+		width: 100%; *@
+		right: 0;
+		top: 0px;
+		min-width: 100%;
+		min-height: 100%;
+		z-index: -1;
+	}
 </style>
 
 <script>
@@ -365,6 +377,10 @@
 	};
 
 </script>
+
+<video autoplay muted loop id="backgroundVideo" poster="@Model.SteamBackground">
+	<source src="@Model.SteamBackground" type="video/webm">
+</video>
 
 <div class="text-center fade-in container">
 	<div class="row">

--- a/DistanceTracker/Views/Player/Index.cshtml
+++ b/DistanceTracker/Views/Player/Index.cshtml
@@ -291,8 +291,12 @@
 
 						// Create the chart for each level
 						const ctx = document.getElementById(`histogram-${levelHistogramData.leaderboard.leaderboardName}`).getContext('2d');
+						const defaultImage = new Image();
 						const image = new Image();
 						image.src = `${levelHistogramData.leaderboard.imageURL}`;
+						
+						const imageToUse = image.height != 0 ? image : defaultImage;  // Use a blank image if the image can't be found
+
 						const histogramChart = new Chart(ctx, {
 							type: 'bar',
 							data: {
@@ -332,17 +336,16 @@
 								{
 									id: `custom_canvas_background_image_${levelHistogramData.leaderboard.leaderboardName}`,
 									beforeDraw: (chart) => {
-										console.log(image);
-										if (image.complete) {
+										if (imageToUse.complete) {
 											const ctx = chart.ctx;
 											const {top, left, width, height} = chart.chartArea;
-											const x = left + width / 2 - image.width / 2;
-											const y = top + height / 2 - image.height / 2;
+											const x = left + width / 2 - imageToUse.width / 2;
+											const y = top + height / 2 - imageToUse.height / 2;
 											ctx.globalAlpha = 0.15;
-											ctx.drawImage(image, x, y);
+											ctx.drawImage(imageToUse, x, y);
 											ctx.globalAlpha = 1;
 										} else {
-											image.onload = () => chart.draw();
+											imageToUse.onload = () => chart.draw();
 										}
 									}
 								}

--- a/DistanceTracker/Views/Search/Index.cshtml
+++ b/DistanceTracker/Views/Search/Index.cshtml
@@ -35,7 +35,7 @@
 					var row = $(`
 						<div class="col-12 text-left pb-2 pt-2">
 							<div class="entry-img no-wrap fade-in d-inline-block align-middle" style="width: 300px;">
-								<img src="${player.steamAvatar}" class="mr-2"/>
+								<img src="${player.steamAvatar}" class="mr-2 profile-thumb"/>
 								<a class="link" href="/Player?steamID=${player.steamID}">${player.name}</a>
 							</div>
 							<div class="fade-in d-inline-block align-middle">${player.steamID}</div>

--- a/DistanceTracker/Views/Shared/_Layout.cshtml
+++ b/DistanceTracker/Views/Shared/_Layout.cshtml
@@ -48,7 +48,20 @@
 			</button>
 			<div class="collapse navbar-collapse" id="navbarNavAltMarkup">
 				<div class="navbar-nav">
-					<a class="nav-item nav-link" href="/Leaderboard/Global">Leaderboard</a>
+					<div class="nav-item dropdown">
+						<a class="nav-link" data-toggle="dropdown" href="#" role="button">Leaderboards</a>
+						<div class="dropdown-menu">
+							<a class="dropdown-item" href="/Leaderboard/OfficialGlobal">All Official Levels</a>
+							<a class="dropdown-item" href="/Leaderboard/OfficialSprint">Official Sprint</a>
+							<a class="dropdown-item" href="/Leaderboard/OfficialChallenge">Official Challenge</a>
+							<a class="dropdown-item" href="/Leaderboard/OfficialStunt">Official Stunt</a>
+							<div class="dropdown-divider"></div>
+							<a class="dropdown-item" href="/Leaderboard/WorkshopGlobal">All Workshop Levels</a>
+							<a class="dropdown-item" href="/Leaderboard/WorkshopSprint">Workshop Sprint</a>
+							<a class="dropdown-item" href="/Leaderboard/WorkshopChallenge">Workshop Challenge</a>
+							<a class="dropdown-item" href="/Leaderboard/WorkshopStunt">Workshop Stunt</a>
+						</div>
+					</div>
 					<div class="nav-item dropdown">
 						<a class="nav-link" data-toggle="dropdown" href="#" role="button">Activity</a>
 						<div class="dropdown-menu">
@@ -68,11 +81,7 @@
 					<a class="nav-item nav-link" href="/Player/Compare">Compare</a>
 				</div>
 			</div>
-			@if (controller == "Home" && action == "Index")
-			{
-
-			}
-			else
+			@if (controller != "Home" || action != "Index")
 			{
 			<form class="form-inline" action="/search" method="get">
 				<input class="form-control mr-sm-2" name="q" placeholder="Enter player name">

--- a/DistanceTracker/Views/Shared/_Layout.cshtml
+++ b/DistanceTracker/Views/Shared/_Layout.cshtml
@@ -65,7 +65,7 @@
 					<div class="nav-item dropdown">
 						<a class="nav-link" data-toggle="dropdown" href="#" role="button">Activity</a>
 						<div class="dropdown-menu">
-							<a class="dropdown-item" href="/Home/GlobalActivity">Global Activity</a>
+							<a class="dropdown-item" href="/Home/ActivityFeed">Activity Feed</a>
 							<a class="dropdown-item" href="/Home/WRActivity">Recent WRs</a>
 							<a class="dropdown-item" href="/Home/Top100Activity">Recent Top 100s</a>
 						</div>

--- a/DistanceTracker/appsettings.Development.json
+++ b/DistanceTracker/appsettings.Development.json
@@ -5,7 +5,5 @@
       "System": "Information",
       "Microsoft": "Information"
     }
-  },
-  "ConnectionString": "",
-  "SteamAPIKey": ""
+  }
 }

--- a/DistanceTracker/appsettings.json
+++ b/DistanceTracker/appsettings.json
@@ -4,7 +4,5 @@
       "Default": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "ConnectionString": "",
-  "SteamAPIKey": ""
+  "AllowedHosts": "*"
 }

--- a/DistanceTracker/wwwroot/css/site.css
+++ b/DistanceTracker/wwwroot/css/site.css
@@ -361,6 +361,10 @@ hr {
 	font-size: 0.85rem;
 }
 
+.profile-thumb {
+	height: 32px;
+}
+
 .info-card {
 	background-color: #212529;
 	padding: 15px;
@@ -368,4 +372,8 @@ hr {
 
 .rounded-corners {
 	border-radius: 0.25rem;
+}
+
+.rounded-corners-large {
+	border-radius: 0.5rem;
 }

--- a/DistanceTracker/wwwroot/css/site.css
+++ b/DistanceTracker/wwwroot/css/site.css
@@ -360,3 +360,12 @@ hr {
 .fa-xxs {
 	font-size: 0.85rem;
 }
+
+.info-card {
+	background-color: #212529;
+	padding: 15px;
+}
+
+.rounded-corners {
+	border-radius: 0.25rem;
+}


### PR DESCRIPTION
Pretty big PR, but the main end result is that workshop maps, challenge maps, and stunt maps are all now supported.

A more complete list of changes and features:
 - Deprecates appsettings.json
 - Restricts the Global Officials leaderboard to just official maps
 - Adds a page for Global Sprint, Global Challenge, Global Stunt, Workshop Global, Workshop Sprint, Workshop Challenge, and Workshop Stunt leaderboards
 - Improves several slow pages and queries by a significant amount
 - Limits histogram results on the player page to just official maps for now.
 - Updates the appearance of the level page and fixes a few css issues the page had
 - Adds support for steam background images on player page (hit the refresh button next to a player's name to update it)
 - Updates the appearance of the player profile page now that it can have arbitrary steam backgrouns
 - Updates level pages to properly sort and display stunt scores (eV)
 - Adds preliminary support for animated steam avatars. Still needs some testing.
 - Adds a search bar to the level list that searches by level name
 - Fixes a bug where levels on the level list page would sometimes be missing data for "Last Activity"
 - Updates activity pages to properly display stunt scores
 - Adds some really basic responsiveness to the leaderboard pages so that they don't look totally terrible on narrower windows